### PR TITLE
Add to the frontend hard-coded support for a video on the TechNotes homepage

### DIFF
--- a/frontend/components/LookupValue.tsx
+++ b/frontend/components/LookupValue.tsx
@@ -70,6 +70,12 @@ export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) =>
             </Tooltip>
         }
         case "String":
+            // Temporary special case hack for the TechNotes hompage until we support video:
+            if (value.value === "$TN_HOME_VIDEO$") {
+                return <div className="max-h-[400px]">
+                    <video src="https://f000.backblazeb2.com/file/technotes/technotes-home.mp4" muted autoPlay loop className="block mx-auto w-full h-full max-h-[400px] max-w-none "></video>
+                </div>;
+            }
             return <>{value.value}</>;
         case "InlineMarkdownString":
             return <InlineMDT mdt={value.value} context={props.mdtContext} />;


### PR DESCRIPTION
<img width="1581" alt="Screen Shot 2022-01-15 at 2 06 45 PM" src="https://user-images.githubusercontent.com/945577/149639163-28549343-493e-4c9b-998c-fdcd76200ac5.png">

Later we should maybe support parametrized HTML templates that can be defined at the site config level and then will be rendered in an iframe?