### PR TITLE
Fix: frontend image wouldn't start due to missing plugin dependencies

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,6 +22,7 @@ COPY --from=transpile /build/neolace-api/ /neolace/neolace-api/
 # Dependencies
 RUN apk add --no-cache git
 RUN npm ci --also=dev
+RUN for plugdir in plugins/*/; do cd $plugdir && npm ci --also=dev; cd -; done
 RUN npm run compile:i18n
 
 # The frontend runs on port 5555


### PR DESCRIPTION
Trying to deploy #21 , I got this frontend error:

```
Failed to compile.
./plugins/search/components/Highlight.tsx:1:34
Type error: Cannot find module 'react-instantsearch-dom' or its corresponding type declarations.
```