### PR TITLE
Bump dependency versions, consolidate on Deno std v0.120.0

### DIFF
--- a/backend/import_map.json
+++ b/backend/import_map.json
@@ -1,6 +1,6 @@
 {
     "imports": {
         "neolace/": "./neolace/",
-        "std/": "https://deno.land/std@0.113.0/"
+        "std/": "https://deno.land/std@0.120.0/"
     }
 }

--- a/backend/neolace/deps/authn-deno.ts
+++ b/backend/neolace/deps/authn-deno.ts
@@ -1,1 +1,1 @@
-export * from "https://raw.githubusercontent.com/bradenmacdonald/authn-deno/f82ca64570db36a0ede2f40c34345a947ccfff2c/mod.ts";
+export * from "https://raw.githubusercontent.com/bradenmacdonald/authn-deno/e17a0ad8cc86011535fcf9d038df9f451793571f/mod.ts";

--- a/backend/neolace/deps/drash.ts
+++ b/backend/neolace/deps/drash.ts
@@ -1,4 +1,4 @@
 /**
  * Drash is a REST microframework for Deno's HTTP server with zero 3rd party dependencies.
  */
-export * as Drash from "https://deno.land/x/drash@v2.2.0/mod.ts";
+export * as Drash from "https://deno.land/x/drash@v2.4.0/mod.ts";

--- a/backend/neolace/deps/vertex-framework.ts
+++ b/backend/neolace/deps/vertex-framework.ts
@@ -1,3 +1,3 @@
 // For local dev:
 // export * from "../../../../vertex-framework/vertex/index.ts";
-export * from "https://raw.githubusercontent.com/neolace-dev/vertex-framework/main/vertex/index.ts";
+export * from "https://raw.githubusercontent.com/neolace-dev/vertex-framework/f5e5a577518307d609ded1e16aa7f1fe1cb02b64/vertex/index.ts";

--- a/neolace-api/_compile.ts
+++ b/neolace-api/_compile.ts
@@ -1,8 +1,8 @@
 
 // TODO: in the future this could be replaced with https://github.com/denoland/dnt
 
-import { ensureDir } from "https://deno.land/std@0.99.0/fs/mod.ts";
-import { dirname } from "https://deno.land/std@0.99.0/path/mod.ts";
+import { ensureDir } from "https://deno.land/std@0.120.0/fs/ensure_dir.ts";
+import { dirname } from "https://deno.land/std@0.120.0/path/mod.ts";
 
 const distDir = "dist/";
 

--- a/neolace-api/src/markdown-mdt.test.ts
+++ b/neolace-api/src/markdown-mdt.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.116.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.120.0/testing/asserts.ts";
 import { AnyInlineNode, InlineNode, TopLevelNode } from "./markdown-mdt-ast.ts";
 import {
     tokenizeInlineMDT,


### PR DESCRIPTION
Update several dependencies.
As much as possible, this tries to get all dependencies using the same version of Deno std. (0.120.0), to reduce the number of files involved in the project and speed up type checks.

Output of `deno info neolace/api/server.ts --import-map import_map.json`

|   | Dependencies |
| ------------- | ------------- |
|Before| 428 unique (total 2.94MB) |
|After: | 365 unique (total 2.67MB) |
