### PR TITLE
Fix: Drash was corrupting uploaded binary files

### DIFF
--- a/backend/neolace/api/site/{siteShortId}/draft/{draftId}/file.ts
+++ b/backend/neolace/api/site/{siteShortId}/draft/{draftId}/file.ts
@@ -33,7 +33,7 @@ export class DraftFileResource extends NeolaceHttpResource {
         //  const contentType = request.headers.get("Content-Type");
         //  const bodyStream = request.body;
         // So do this instead:
-        const formFile = request.bodyParam<{ content: string; type: string; size: number }>("file");
+        const formFile = request.bodyParam<{ content: Uint8Array; type: string; size: number }>("file");
         if (!formFile) {
             throw new api.InvalidRequest(
                 api.InvalidRequestReason.OtherReason,
@@ -41,7 +41,7 @@ export class DraftFileResource extends NeolaceHttpResource {
             );
         }
         const contentType = formFile.type;
-        const bodyStream = readableStreamFromIterable([new TextEncoder().encode(formFile.content)]);
+        const bodyStream = readableStreamFromIterable([formFile.content]);
 
         if (contentType === null || bodyStream === null) {
             throw new api.InvalidRequest(

--- a/backend/neolace/deps/drash.ts
+++ b/backend/neolace/deps/drash.ts
@@ -1,4 +1,7 @@
 /**
  * Drash is a REST microframework for Deno's HTTP server with zero 3rd party dependencies.
  */
-export * as Drash from "https://deno.land/x/drash@v2.4.0/mod.ts";
+//export * as Drash from "https://deno.land/x/drash@v2.4.0/mod.ts";
+
+// Using a fork until https://github.com/drashland/drash/issues/604 is fixed.
+export * as Drash from "https://raw.githubusercontent.com/neolace-dev/drash/d387d5f346bf2553ba324640b8f06e93884b9643/mod.ts";


### PR DESCRIPTION
Image uploads weren't working properly, and I traced it to https://github.com/drashland/drash/issues/604#issuecomment-1032150806