### PR TITLE
Improve display of default Ponderosa Pine example

### DIFF
--- a/backend/neolace/core/lookup/expressions/image.test.ts
+++ b/backend/neolace/core/lookup/expressions/image.test.ts
@@ -38,7 +38,7 @@ group(import.meta, () => {
                 imageUrl: result.data.imageUrl,
                 blurHash: "LCDu}B~VNu9Z0LxGNH9u$zjYWCt7",
                 size: 1581898,
-                sizing: ImageSizingMode.Contain,
+                sizing: ImageSizingMode.Cover,
                 width: 3504,
                 height: 2336,
                 link: new EntryValue(defaultData.entries.imgPonderosaTrunk.id),

--- a/backend/neolace/sample-data/plantdb/images.ts
+++ b/backend/neolace/sample-data/plantdb/images.ts
@@ -5,6 +5,7 @@ import { files } from "./datafiles.ts";
 import { AcceptDraft, AddFileToDraft, CreateDraft, UpdateDraft } from "neolace/core/edit/Draft.ts";
 import { getGraph } from "neolace/core/graph.ts";
 import { entryData } from "./content.ts";
+import { ImageSizingMode } from "neolace/deps/neolace-api.ts";
 
 export async function createImages(siteId: VNID) {
     const graph = await getGraph();
@@ -37,7 +38,7 @@ export async function createImages(siteId: VNID) {
                 code: "UpdateEntryFeature",
                 data: {
                     entryId: entryData.imgPonderosaTrunk.id,
-                    feature: { featureType: "Image", draftFileId },
+                    feature: { featureType: "Image", draftFileId, setSizing: ImageSizingMode.Cover },
                 },
             },
             // This image relates to the ponderosa pine:


### PR DESCRIPTION
This displays it using "cover":

<img width="1823" alt="Screen Shot 2022-02-08 at 3 11 52 PM" src="https://user-images.githubusercontent.com/945577/153091279-36339ca8-27f8-40f3-af59-ae6fe9649203.png">
