### PR TITLE
Bump Drash to v2.5.2

### DIFF
--- a/backend/neolace/deps/drash.ts
+++ b/backend/neolace/deps/drash.ts
@@ -1,7 +1,4 @@
 /**
  * Drash is a REST microframework for Deno's HTTP server with zero 3rd party dependencies.
  */
-//export * as Drash from "https://deno.land/x/drash@v2.4.0/mod.ts";
-
-// Using a fork until https://github.com/drashland/drash/issues/604 is fixed.
-export * as Drash from "https://raw.githubusercontent.com/neolace-dev/drash/d387d5f346bf2553ba324640b8f06e93884b9643/mod.ts";
+export * as Drash from "https://deno.land/x/drash@v2.5.2/mod.ts";


### PR DESCRIPTION
We no longer need to use a fork since https://github.com/drashland/drash/issues/604 has been fixed.