### PR TITLE
Use presigned URLs to download files

### DIFF
--- a/backend/neolace/core/lookup/expressions/files.test.ts
+++ b/backend/neolace/core/lookup/expressions/files.test.ts
@@ -1,5 +1,5 @@
 import { SYSTEM_VNID, VNID } from "neolace/deps/vertex-framework.ts";
-import { assertEquals, assertRejects, beforeAll, group, setTestIsolation, test } from "neolace/lib/tests.ts";
+import { assert, assertEquals, assertRejects, beforeAll, group, setTestIsolation, test } from "neolace/lib/tests.ts";
 import { graph } from "neolace/core/graph.ts";
 import { EntryValue, FileValue, IntegerValue, PageValue } from "../values.ts";
 import { Files } from "./files.ts";
@@ -111,20 +111,21 @@ group(import.meta, () => {
 
             const result = await evalExpression(expression);
 
+            assert(result instanceof PageValue);
+            assert(result.values[0].url.startsWith(firstPdf.url));
+            assert(result.values[1].url.startsWith(secondPdf.url));
             assertEquals(
                 result,
                 new PageValue([
                     new FileValue(
                         "first.pdf",
-                        firstPdf.url +
-                            `?response-content-disposition=${encodeURIComponent(`inline; filename=first.pdf`)}`,
+                        result.values[0].url,
                         "application/pdf",
                         firstPdf.size,
                     ),
                     new FileValue(
                         "second.pdf",
-                        secondPdf.url +
-                            `?response-content-disposition=${encodeURIComponent(`inline; filename=second.pdf`)}`,
+                        result.values[1].url,
                         "application/pdf",
                         secondPdf.size,
                     ),

--- a/backend/neolace/core/objstore/DataFile.ts
+++ b/backend/neolace/core/objstore/DataFile.ts
@@ -12,6 +12,7 @@ import {
 } from "neolace/deps/vertex-framework.ts";
 import { config } from "neolace/app/config.ts";
 import { FileMetadata, FileMetadataSchema } from "./detect-metadata.ts";
+import { getSignedDownloadUrl } from "./objstore.ts";
 
 /**
  * A data file uploaded to Neolace, such as an image, PDF, CSV file, etc.
@@ -103,7 +104,7 @@ export function publicUrl(): DerivedProperty<string> {
         DataFile,
         (df) => df.filename,
         (data) => {
-            return `${config.objStorePublicUrlPrefix}/${data.filename}`; // This is duplicated in lookup/expressions/files.ts until we can refactor vertex framework
+            return `${config.objStorePublicUrlPrefix}/${data.filename}`; // This doesn't use publicUrlForDataFile below because this is synchronous.
         },
     );
 }
@@ -119,4 +120,17 @@ export function metadata(): DerivedProperty<FileMetadata> {
             return JSON.parse(data.metadataJSON ?? "{}");
         },
     );
+}
+
+/**
+ * Get the public URL to download a file from object storage.
+ * @param filename The underlying filename of the DataFile object
+ * @param displayFilename The friendly filename that users should see if they save the file
+ */
+export async function publicUrlForDataFile(filename: string, displayFilename?: string): Promise<string> {
+    if (!displayFilename) {
+        return `${config.objStorePublicUrlPrefix}/${filename}`;
+    } else {
+        return getSignedDownloadUrl(filename, displayFilename);
+    }
 }

--- a/backend/neolace/core/objstore/objstore.ts
+++ b/backend/neolace/core/objstore/objstore.ts
@@ -97,3 +97,12 @@ export async function uploadFileToObjStore(
         metadata,
     };
 }
+
+export async function getSignedDownloadUrl(filename: string, displayFilename?: string): Promise<string> {
+    return objStoreClient.presignedGetObject(
+        filename,
+        displayFilename
+            ? { responseParams: { "response-content-disposition": `inline; filename=${displayFilename}` } }
+            : {},
+    );
+}

--- a/backend/neolace/deps/s3.ts
+++ b/backend/neolace/deps/s3.ts
@@ -1,1 +1,1 @@
-export { S3Client } from "https://raw.githubusercontent.com/bradenmacdonald/deno-s3-lite-client/812ba3be428eca1e3ee09fba03315277d84b48cf/mod.ts";
+export { S3Client } from "https://deno.land/x/s3_lite_client@0.2.0/mod.ts";


### PR DESCRIPTION
This will make PDFs download with a useful filename, and will also open the door to more secure distribution of files in the future.