### PR TITLE
Fix: Next.js 12.1 doesn't include node-fetch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "keratin-authn": "1.3.2",
     "neolace-api": "file:../neolace-api/dist/",
     "next": "12.1.0",
+    "node-fetch": "3.2.3",
     "react": "17.0.2",
     "react-blurhash": "0.1.3",
     "react-dom": "17.0.2",


### PR DESCRIPTION
Was giving a build error when we deployed the frontend.