### PR TITLE
Resize the graph visualization if the window is resized.

### DIFF
--- a/frontend/components/Graph.tsx
+++ b/frontend/components/Graph.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { api } from 'lib/api-client';
 import { MDTContext } from './markdown-mdt/mdt';
 import G6, { Graph, IG6GraphEvent, NodeConfig } from '@antv/g6';
+import { useResizeObserver } from './utils/resizeObserverHook';
 
 interface GraphProps {
     value: api.GraphValue;
@@ -74,9 +75,8 @@ export const LookupGraph: React.FunctionComponent<GraphProps> = (props) => {
     React.useEffect(() => {
         if (!graph && ref.current) {
             const container = ref.current;
-            const width = container.scrollWidth;
-            const height = container.scrollHeight || 500;
-            console.log("Here")
+            const width = container.clientWidth;
+            const height = container.clientHeight;
             const newGraph = new G6.Graph({
                 container,
                 width,
@@ -112,5 +112,17 @@ export const LookupGraph: React.FunctionComponent<GraphProps> = (props) => {
         }
     }, [ref.current]);
 
-    return <div ref={ref}></div>;
+    // Automatically resize the graph if the containing element changes size.
+    const handleSizeChange = React.useCallback(() => {
+        if (!graph || graph.destroyed) { return; }
+        const width = ref.current!.clientWidth, height = ref.current!.clientHeight;
+        if (graph.getWidth() !== width || graph.getHeight() !== height) {
+            graph.changeSize(width, height);
+            graph.layout();
+            graph.fitView();
+        }
+    }, [graph]);
+    useResizeObserver(ref, handleSizeChange);
+
+    return <div ref={ref} className="w-full aspect-square md:aspect-video border-2 border-gray-200 overflow-hidden"></div>;
 };  

--- a/frontend/components/utils/resizeObserverHook.tsx
+++ b/frontend/components/utils/resizeObserverHook.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+/**
+ * This React hook can be used to watch a particular HTML element, and call a callback function if the element's size
+ * has changed.
+ * @param ref A React 'ref' object for the HTML element that we want to observe for size changes.
+ * @param callback The function to call when the element's size has changed.
+ */
+export const useResizeObserver = (ref: React.RefObject<Element>, callback: () => void) => {
+
+    // Use a ref to wrap the callback so that our ref never changes:
+    const callbackRef = React.useRef<() => void>(callback);
+    if (callbackRef.current !== callback) {
+        callbackRef.current = callback;
+    }
+    // Since this handler uses the ref to call the callback, this handler never changes:
+    const handleSizeChange = React.useCallback(() => {
+        if (callbackRef.current) { callbackRef.current(); }
+    }, []);
+
+    const [observer] = React.useState<ResizeObserver>(new ResizeObserver(handleSizeChange));
+
+    React.useEffect(() => {
+        if (ref.current) {
+            observer.observe(ref.current);
+        }
+        // Cleanup:
+        return () => {
+            observer.disconnect();
+        };
+    }, [ref.current]);
+
+}


### PR DESCRIPTION
@ritec03 This is a minor change to the graph visualization to make it so that the graph will resize if the browser window is resized.