### PR TITLE
Hot reload the graph whenever its config or data changes

### DIFF
--- a/frontend/components/Graph.tsx
+++ b/frontend/components/Graph.tsx
@@ -4,12 +4,8 @@
 import React from "react";
 import { api } from "lib/api-client";
 import { MDTContext } from "./markdown-mdt/mdt";
-import G6, { Graph, IG6GraphEvent, NodeConfig } from "@antv/g6";
+import G6, { Graph, GraphOptions, IG6GraphEvent, NodeConfig } from "@antv/g6";
 import { useResizeObserver } from "./utils/resizeObserverHook";
-import { useRouter } from "next/router";
-import { Tooltip } from "./widgets/Tooltip";
-import ReactDOM from "react-dom";
-import Link from "next/link";
 import { GraphTooltip } from "./GraphTooltip";
 
 interface GraphProps {
@@ -105,7 +101,6 @@ const truncateString = (str: string, maxWidth: number, fontSize: number) => {
  * Display a graph visualization.
  */
 export const LookupGraph: React.FunctionComponent<GraphProps> = (props) => {
-    const router = useRouter();
     const data = React.useMemo(() => {
         return convertValueToData(props.value, props.mdtContext.refCache);
     }, [props.value]);
@@ -113,125 +108,151 @@ export const LookupGraph: React.FunctionComponent<GraphProps> = (props) => {
     const ref = React.useRef<HTMLDivElement>(null);
     const [graph, setGraph] = React.useState<Graph | null>(null);
 
+    // Create a reference (an object that holds mdtContext) that we can pass to the tooltip,
+    // so that the tooltip can always access the mdtContext and we don't have to re-create the
+    // tooltip plugin whenever the mdtContext changes.
+    const mdtContextRef = React.useRef<MDTContext>(props.mdtContext);
+    React.useEffect(() => { mdtContextRef.current = props.mdtContext; }, [props.mdtContext]);
+
+    // Construct the tooltip plugin.
+    const tooltip = React.useMemo(() => 
+        new GraphTooltip(mdtContextRef), []
+    );
+    // Our graph configuration
+    const graphConfig: Partial<GraphOptions> = React.useMemo(() => ({
+        plugins: [tooltip],
+        layout: {
+            type: 'force',
+            preventOverlap: true,
+            nodeSize: [200, 50],
+            nodeSpacing: 60,
+            // clustering: true,
+
+            // type: "dagre",
+            // rankdir: "TB", // The center of the graph by default
+            // align: "DL",
+            // nodesep: 50,
+            // ranksep: 100,
+            // controlPoints: true,
+
+            // type: 'radial',
+            // unitRadius: 1000,
+            // preventOverlap: true,
+            // nodeSize: 200,
+            // nodeSpacing: 4000,
+            // linkDistance: 400,
+            // sortBy: 'comboId',
+            // sortStrength: 100,
+
+            // type: 'comboCombined',
+            // nodeSize: 200,
+            // outerLayout: new G6.Layout['gForce']({
+            //     linkDistance: 2500,
+            // }),
+        },
+        defaultNode: {
+            type: "modelRect",
+            size: [200, 50],
+            // The configuration of the logo icon in the node
+            logoIcon: {
+                // Whether to show the icon. false means hide the icon
+                show: false,
+                x: 0,
+                y: 0,
+                // the image url of icon
+                img: "https://gw.alipayobjects.com/zos/basement_prod/4f81893c-1806-4de4-aff3-9a6b266bc8a2.svg",
+                width: 16,
+                height: 16,
+                // Adjust the left/right offset of the icon
+                offset: 0,
+            },
+            // The configuration of the state icon in the node
+            stateIcon: {
+                // Whether to show the icon. false means hide the icon
+                show: false,
+                x: 0,
+                y: 0,
+                // the image url of icon
+                img: "https://gw.alipayobjects.com/zos/basement_prod/300a2523-67e0-4cbf-9d4a-67c077b40395.svg",
+                width: 16,
+                height: 16,
+                // Adjust the left/right offset of the icon
+                offset: -5,
+            },
+            preRect: {},
+        },
+        defaultEdge: {
+            type: "line",
+            /* configure the bending radius and min distance to the end nodes */
+            style: {
+                radius: 10,
+                offset: 30,
+                endArrow: {
+                    path: G6.Arrow.triangle(10, 20, 0),
+                    d: 0,
+                    fill: "#ddd",
+                },
+                lineWidth: 2,
+                stroke: "#ddd",
+                /* and other styles */
+                // stroke: '#F6BD16',
+            },
+        },
+        modes: {
+            default: ["drag-canvas", "click-select", "zoom-canvas"],
+        },
+    }), [tooltip]);
+
+    // Initialize the G6 graph, once we're ready
     React.useEffect(() => {
-        if (!graph && ref.current) {
-            const container = ref.current;
-            const width = container.clientWidth;
-            const height = container.clientHeight;
-            const tooltip = new GraphTooltip(props.mdtContext);
-            const newGraph = new G6.Graph({
-                container,
-                width,
-                height,
-                plugins: [tooltip],
-                layout: {
-                    type: 'force',
-                    preventOverlap: true,
-                    nodeSize: 150,
-                    nodeSpacing: 100,
-                    // clustering: true,
-                    // type: "dagre",
-                    // rankdir: "TB", // The center of the graph by default
-                    // align: "DL",
-                    // nodesep: 50,
-                    // ranksep: 100,
-                    // controlPoints: true,
-                    // type: 'radial',
-                    // unitRadius: 1000,
-                    // preventOverlap: true,
-                    // nodeSize: 200,
-                    // nodeSpacing: 4000,
-                    // linkDistance: 400,
-                    // sortBy: 'comboId',
-                    // sortStrength: 100,
-                    // type: 'comboCombined',
-                    // nodeSize: 200,
-                    // outerLayout: new G6.Layout['gForce']({
-                    //     linkDistance: 2500,
-                    // }),
-                },
-                defaultNode: {
-                    type: "modelRect",
-                    // The configuration of the logo icon in the node
-                    logoIcon: {
-                        // Whether to show the icon. false means hide the icon
-                        show: false,
-                        x: 0,
-                        y: 0,
-                        // the image url of icon
-                        img: "https://gw.alipayobjects.com/zos/basement_prod/4f81893c-1806-4de4-aff3-9a6b266bc8a2.svg",
-                        width: 16,
-                        height: 16,
-                        // Adjust the left/right offset of the icon
-                        offset: 0,
-                    },
-                    // The configuration of the state icon in the node
-                    stateIcon: {
-                        // Whether to show the icon. false means hide the icon
-                        show: false,
-                        x: 0,
-                        y: 0,
-                        // the image url of icon
-                        img: "https://gw.alipayobjects.com/zos/basement_prod/300a2523-67e0-4cbf-9d4a-67c077b40395.svg",
-                        width: 16,
-                        height: 16,
-                        // Adjust the left/right offset of the icon
-                        offset: -5,
-                    },
-                    preRect: {},
-                },
-                defaultEdge: {
-                    type: "line",
-                    /* configure the bending radius and min distance to the end nodes */
-                    style: {
-                        radius: 10,
-                        offset: 30,
-                        endArrow: {
-                            path: G6.Arrow.triangle(10, 20, 0),
-                            d: 0,
-                            fill: "#ddd",
-                        },
-                        lineWidth: 2,
-                        stroke: "#ddd",
-                        /* and other styles */
-                        // stroke: '#F6BD16',
-                    },
-                },
-                modes: {
-                    default: ["drag-canvas", "click-select", "zoom-canvas"],
-                },
-            });
-            newGraph.data(data);
-            newGraph.render();
-            setGraph(newGraph);
-
-            newGraph.on("node:dragstart", function (e) {
-                newGraph.layout();
-                refreshDragedNodePosition(e);
-            });
-            newGraph.on("node:drag", function (e) {
-                const forceLayout = newGraph.get("layoutController").layoutMethods[0];
-                forceLayout.execute();
-                refreshDragedNodePosition(e);
-            });
-            newGraph.on("node:dragend", function (e) {
-                if (!e.item) {
-                    return;
-                }
-                // e.item.get("model").fx = null;
-                // e.item.get("model").fy = null;
-            });
-
-            // newGraph.on("node:click", function (e){
-            //     const entryId = e.item?.getModel().id;
-            //     router.push(`/entry/${entryId}`);
-            // })
-
-            // Fix bug that occurs in Firefox only: scrolling the mouse wheel on the graph also scrolls the page.
-            ref.current.addEventListener("MozMousePixelScroll", (e) => {
-                e.preventDefault();
-            }, { passive: false });
+        if (!ref.current) {
+            return;  // We can't (re-)initialize the graph yet, because we don't have a valid reference to the <div> that will hold it.
         }
+        const container = ref.current;
+        const width = container.clientWidth;
+        const height = container.clientHeight;
+        const newGraph = new G6.Graph({container, width, height, ...graphConfig});
+        setGraph((oldGraph) => {
+            if (oldGraph) {
+                // If there already was a graph, destroy it because we're about to re-create it.
+                oldGraph.destroy();
+            }
+            return newGraph;
+        });
+    }, [ref, graphConfig]);
+
+    // Set the graph data and render it whenever the data has changed or the graph has been re-initialized:
+    React.useEffect(() => {
+        if (!graph || graph.destroyed) { return; }
+        graph.data(data);
+        graph.render();
+    }, [graph, data]);
+
+    // Set up G6 event handlers whenever the graph has been initialized for the first time or re-initialized
+    React.useEffect(() => {
+        if (!graph || graph.destroyed) { return; }
+        // Allow users to drag nodes around:
+        graph.on("node:dragstart", function (e) {
+            graph.layout();
+            refreshDragedNodePosition(e);
+        });
+        graph.on("node:drag", function (e) {
+            const forceLayout = graph.get("layoutController").layoutMethods[0];
+            forceLayout.execute();
+            refreshDragedNodePosition(e);
+        });
+        graph.on("node:dragend", function (e) {
+            if (!e.item) { return; }
+            // e.item.get("model").fx = null;
+            // e.item.get("model").fy = null;
+        });
+    }, [graph]);
+
+    // Fix bug that occurs in Firefox only: scrolling the mouse wheel on the graph also scrolls the page.
+    React.useEffect(() => {
+        ref.current?.addEventListener("MozMousePixelScroll", (e) => {
+            e.preventDefault();
+        }, { passive: false });
     }, [ref.current]);
 
     // Automatically resize the graph if the containing element changes size.

--- a/frontend/components/GraphTooltip.tsx
+++ b/frontend/components/GraphTooltip.tsx
@@ -2,15 +2,12 @@
  * A graph that is displayed as the result of the .graph() lookup function.
  */
 import React from "react";
-import G6, { Graph, IG6GraphEvent, NodeConfig } from "@antv/g6";
+import G6 from "@antv/g6";
 import ReactDOM from "react-dom";
-import Link from "next/link";
-import { api } from "lib/api-client";
 import { InlineMDT, MDTContext } from "./markdown-mdt/mdt";
 
 export class GraphTooltip extends G6.Tooltip {
-    constructor(mdtContext: MDTContext) {
-        const refCache = mdtContext.refCache;
+    constructor(mdtContext: React.RefObject<MDTContext>) {
         super({
             offsetX: 10,
             offsetY: 10,
@@ -22,9 +19,10 @@ export class GraphTooltip extends G6.Tooltip {
             // custom the tooltip's content
             // 自定义 tooltip 内容
             getContent: (e) => {
+                const refCache = mdtContext.current?.refCache;
                 const outDiv = document.createElement("div");
                 // const root = ReactDOM.createRoot(outDiv); //for React 18
-                if (!e || !e.item) {
+                if (!e || !e.item || !refCache) {
                     return outDiv;
                 }
                 const node = e.item.getModel();


### PR DESCRIPTION
This changes how we initialize the G6 Graph in our `LookupGraph` React component, using [React hooks](https://reactjs.org/docs/hooks-intro.html).

The upside is that with "hot reloading", now anytime you make a slight change to the graph configuration, the graph will instantly reload and show the changes.

The downside is that anytime you make a change to the code, your work to manually position nodes on the graph will be lost.