### PR TITLE
Refactor LookupContext

### DIFF
--- a/backend/neolace/api/site/{siteShortId}/entry/{entryId}/_helpers.ts
+++ b/backend/neolace/api/site/{siteShortId}/entry/{entryId}/_helpers.ts
@@ -2,7 +2,7 @@ import { api } from "neolace/api/mod.ts";
 import { C, EmptyResultError, Field, isVNID, VNID, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
 import { Entry } from "neolace/core/entry/Entry.ts";
 import { siteCodeForSite } from "neolace/core/Site.ts";
-import { CachedLookupContext } from "neolace/core/lookup/context.ts";
+import { LookupContext } from "neolace/core/lookup/context.ts";
 import { LookupError } from "neolace/core/lookup/errors.ts";
 import {
     AnnotatedValue,
@@ -81,7 +81,12 @@ export async function getEntry(
     refCache?.addReferenceToEntryId(entryData.id);
 
     const maxValuesPerProp = 5;
-    const lookupContext = new CachedLookupContext(tx, siteId, entryData.id, BigInt(maxValuesPerProp));
+    const lookupContext = new LookupContext({
+        tx,
+        siteId,
+        entryId: entryData.id,
+        defaultPageSize: BigInt(maxValuesPerProp),
+    });
 
     if (flags.has(api.GetEntryFlags.IncludePropertiesSummary)) {
         // Include a summary of property values for this entry (up to 15 importance properties - whose importance is <= 20)
@@ -205,7 +210,7 @@ export async function getEntry(
     if (flags.has(api.GetEntryFlags.IncludeReferenceCache)) {
         // Extract references from the description of this entry
         refCache?.extractMarkdownReferences(entryData.description, { currentEntryId: entryData.id });
-        result.referenceCache = await refCache!.getData(tx, lookupContext);
+        result.referenceCache = await refCache!.getData(lookupContext);
     }
 
     return result;

--- a/backend/neolace/api/site/{siteShortId}/home.ts
+++ b/backend/neolace/api/site/{siteShortId}/home.ts
@@ -1,7 +1,7 @@
 import { api, getGraph, NeolaceHttpResource, permissions } from "neolace/api/mod.ts";
 import { Site } from "neolace/core/Site.ts";
 import { ReferenceCache } from "neolace/core/entry/reference-cache.ts";
-import { CachedLookupContext } from "neolace/core/lookup/context.ts";
+import { LookupContext } from "neolace/core/lookup/context.ts";
 
 export class SiteHomeResource extends NeolaceHttpResource {
     public paths = ["/site/:siteShortId/home"];
@@ -21,9 +21,7 @@ export class SiteHomeResource extends NeolaceHttpResource {
 
         return {
             homePageMD: siteData.homePageMD ?? "",
-            referenceCache: await graph.read((tx) =>
-                refCache.getData(tx, new CachedLookupContext(tx, siteId, undefined))
-            ),
+            referenceCache: await graph.read((tx) => refCache.getData(new LookupContext({ tx, siteId }))),
         };
     });
 }

--- a/backend/neolace/api/site/{siteShortId}/lookup.test.ts
+++ b/backend/neolace/api/site/{siteShortId}/lookup.test.ts
@@ -21,10 +21,6 @@ group("lookup.ts", () => {
         );
 
         assertEquals(result.resultValue, { type: "String", value: "Pinus ponderosa" });
-        assertEquals(
-            result.expressionNormalized,
-            `this.get(prop=[[/prop/${defaultData.schema.properties._propScientificName.id}]])`,
-        );
     });
 
     test("It can evaluate an AUTO relationship property and return a reference cache with details of each entry", async () => {
@@ -63,10 +59,6 @@ group("lookup.ts", () => {
             },
         });
         assertEquals(
-            result.expressionNormalized,
-            `this.get(prop=[[/prop/${defaultData.schema.properties._relImages.id}]])`,
-        );
-        assertEquals(
             result.referenceCache.entries[defaultData.entries.imgPonderosaTrunk.id]?.name,
             defaultData.entries.imgPonderosaTrunk.name,
         );
@@ -92,7 +84,6 @@ group("lookup.ts", () => {
             errorClass: "LookupEvaluationError",
             message: "Date values should be in the format YYYY-MM-DD.",
         });
-        assertEquals(result.expressionNormalized, `date("tribble")`);
     });
 
     // TODO: test permissions, once implemented - make sure lookups can't leak any data.

--- a/backend/neolace/core/entry/features/HeroImage/HeroImage.ts
+++ b/backend/neolace/core/entry/features/HeroImage/HeroImage.ts
@@ -11,7 +11,6 @@ import { EnabledFeature } from "../EnabledFeature.ts";
 import { Entry, siteIdForEntryId } from "neolace/core/entry/Entry.ts";
 import { HeroImageData } from "./HeroImageData.ts";
 import { LookupContext } from "neolace/core/lookup/context.ts";
-import { parseLookupString } from "neolace/core/lookup/parse.ts";
 import { LookupError } from "neolace/core/lookup/errors.ts";
 import { AnnotatedValue, EntryValue, InlineMarkdownStringValue, PageValue } from "neolace/core/lookup/values.ts";
 import { getEntryFeatureData } from "../get-feature-data.ts";
@@ -69,11 +68,11 @@ export const HeroImageFeature = EntryTypeFeature({
      */
     async loadData({ tx, config, entryId, refCache }) {
         const siteId = await siteIdForEntryId(entryId);
-        const context: LookupContext = { tx, siteId, entryId, defaultPageSize: 1n };
+        const context = new LookupContext({ tx, siteId, entryId, defaultPageSize: 1n });
 
         let value;
         try {
-            value = await parseLookupString(config.lookupExpression).getValue(context).then((v) => v.makeConcrete());
+            value = await context.evaluateExpr(config.lookupExpression).then((v) => v.makeConcrete());
         } catch (err: unknown) {
             if (err instanceof LookupError) {
                 log.error(err.message);

--- a/backend/neolace/core/entry/reference-cache.ts
+++ b/backend/neolace/core/entry/reference-cache.ts
@@ -1,10 +1,10 @@
 import { api } from "neolace/api/mod.ts";
-import { C, isVNID, VNID, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
+import { C, isVNID, VNID } from "neolace/deps/vertex-framework.ts";
 import { PropertyType, ReferenceCacheData } from "neolace/deps/neolace-api.ts";
 import { Entry } from "neolace/core/entry/Entry.ts";
 import { siteCodeForSite } from "neolace/core/Site.ts";
 import { Property } from "neolace/core/schema/Property.ts";
-import type { CachedLookupContext } from "neolace/core/lookup/context.ts";
+import type { LookupContext } from "neolace/core/lookup/context.ts";
 
 /**
  * A reference cache contains:
@@ -39,7 +39,7 @@ export class ReferenceCache {
         return this._propertyIdsUsed;
     }
 
-    async getData(tx: WrappedTransaction, lookupContext: CachedLookupContext): Promise<ReferenceCacheData> {
+    async getData(lookupContext: LookupContext): Promise<ReferenceCacheData> {
         const siteCode = await siteCodeForSite(this.siteId);
         const data: ReferenceCacheData = {
             entryTypes: {},
@@ -73,7 +73,7 @@ export class ReferenceCache {
         }
 
         // Entries referenced:
-        const entryReferences = await tx.pull(
+        const entryReferences = await lookupContext.tx.pull(
             Entry,
             (e) => e.id.name.description.friendlyId().type((et) => et.id.name.site((s) => s.id)),
             {
@@ -112,7 +112,7 @@ export class ReferenceCache {
             await evaluateLookupExpressions(lookup);
         }
 
-        const propertyReferences = await tx.pull(
+        const propertyReferences = await lookupContext.tx.pull(
             Property,
             (p) => p.id.name.type.descriptionMD.standardURL.importance.displayAs.site((s) => s.id),
             { where: C`@this.id IN ${Array.from(this.propertyIdsUsed)}` },

--- a/backend/neolace/core/lookup/context.ts
+++ b/backend/neolace/core/lookup/context.ts
@@ -1,100 +1,94 @@
 import { VNID, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
+import { getPluginsForSite } from "../../plugins/loader.ts";
 import { LookupError, LookupParseError } from "./errors.ts";
 
 import type { LookupExpression } from "./expressions/base.ts";
+import { LookupFunctionClass } from "./expressions/functions/base.ts";
 import { parseLookupString } from "./parse.ts";
 import { ErrorValue, LookupValue } from "./values.ts";
 
-/**
- * The lookup context defines some data required to evaluate a lookup expression, like:
- * -> what is the current transaction? (in case we're previewing draft changes)
- * -> what is the current entry ID? (to evaluate "this")
- */
-export interface LookupContext {
-    tx: WrappedTransaction;
-    siteId: VNID;
-    entryId?: VNID;
-    // If lookup result values have to be paginated in this context, what's the default page size?
-    defaultPageSize: bigint;
-}
-
-export class LookupCache {
-    private cache = new Map<string, LookupValue>();
-
-    constructor(
-        public readonly tx: WrappedTransaction,
-        public readonly siteId: VNID,
-        public readonly defaultPageSize: bigint,
-    ) {}
-
-    public async evaluateExprWithCache(expr: LookupExpression, entryId: VNID | undefined) {
-        const prefix = (entryId ?? "") + ":";
-        // Key is the entry ID, then a colon, then the expression in "standard form"
-        const key = prefix + expr.toString();
-        const cachedValue = this.cache.get(key);
-        if (cachedValue !== undefined) {
-            return cachedValue;
-        }
-        // Evaluate the value and cache the result:
-        const context: LookupContext = {
-            tx: this.tx,
-            siteId: this.siteId,
-            defaultPageSize: this.defaultPageSize,
-            entryId,
-        };
-        let value;
-        try {
-            value = await expr.getValue(context);
-        } catch (err: unknown) {
-            if (err instanceof LookupError) {
-                value = new ErrorValue(err);
-            } else {
-                throw err;
-            }
-        }
-        this.cache.set(key, value);
-        return value;
-    }
-}
+// A symbol to pass private data into the LookupContext constructor
+const _internalCache = Symbol("internalCache");
 
 /**
  * A context in which lookup expressions can be evaluated.
+ *
+ * The lookup context defines some data required to evaluate a lookup expression, like:
+ * -> what is the current transaction? (in case we're previewing draft changes)
+ * -> what is the current entry ID? (to evaluate "this")
+ *
  * Has a cache that caches values for optimal performance.
  */
-export class CachedLookupContext implements LookupContext {
-    constructor(
-        public readonly tx: WrappedTransaction,
-        public readonly siteId: VNID,
-        public readonly entryId?: VNID,
-        // If lookup result values have to be paginated in this context, what's the default page size?
-        public readonly defaultPageSize: bigint = 10n,
-        protected _cache: LookupCache = new LookupCache(tx, siteId, defaultPageSize),
-    ) {
+export class LookupContext {
+    public readonly tx: WrappedTransaction;
+    public readonly siteId: VNID;
+    /**
+     * The "current entry", i.e. the value of "this" in any lookup expression in this context. May not be defined, in
+     * cases like the home page which can have lookup expressions but aren't entries themselves.
+     */
+    public readonly entryId?: VNID;
+    /** If lookup result values have to be paginated in this context, what's the default page size? */
+    public readonly defaultPageSize: bigint;
+    private _cache: Map<string, LookupValue>;
+
+    constructor(args: {
+        tx: WrappedTransaction;
+        siteId: VNID;
+        entryId?: VNID;
+        defaultPageSize?: bigint;
+        [_internalCache]?: Map<string, LookupValue>;
+    }) {
+        // protected _cache = new Map<string, LookupValue>(),
+        this.tx = args.tx;
+        this.siteId = args.siteId;
+        this.entryId = args.entryId;
+        this.defaultPageSize = args.defaultPageSize ?? 10n;
+        this._cache = args[_internalCache] ?? new Map<string, LookupValue>();
     }
 
     /**
      * For evaluating lookup expressions in a related entry or not an entry at all, but still sharing the same cache.
      * @param entryId The new entry ID to use in this child context
      */
-    protected getChildContext(entryId: VNID | undefined) {
-        return new CachedLookupContext(this.tx, this.siteId, entryId, this.defaultPageSize, this._cache);
+    protected _getChildContext(entryId: VNID | undefined) {
+        return new LookupContext({
+            tx: this.tx,
+            siteId: this.siteId,
+            entryId,
+            defaultPageSize: this.defaultPageSize,
+            [_internalCache]: this._cache,
+        });
     }
 
     public getContextFor(entryId: VNID | undefined) {
         if (entryId === this.entryId) {
             return this;
         } else {
-            return this.getChildContext(entryId);
+            return this._getChildContext(entryId);
         }
     }
 
-    public evaluateExpr(expr: LookupExpression | string): Promise<LookupValue> {
+    /**
+     * Parse a lookup expression from string to a LookupExpression object.
+     * You should generally use this instead of using parseLookupString directly, because this method is aware of
+     * additional lookup functions that may be available from plugins for the current site.
+     */
+    public async parseLookupString(lookupExpression: string): Promise<LookupExpression> {
+        const extraFunctionsForSite: LookupFunctionClass[] = [];
+        for (const _plugin of await getPluginsForSite(this.siteId)) {
+            // TODO: if the plugin implements a lookup function, push it.
+        }
+        return parseLookupString(lookupExpression, extraFunctionsForSite);
+    }
+
+    /**
+     * Evaluate a lookup expression.
+     */
+    public async evaluateExpr(expr: LookupExpression | string): Promise<LookupValue> {
         if (typeof expr === "string") {
             // We were just given a string, so first parse it to a lookup expression.
-            // We always parse it because this allows us to normalize the expression to make the cache more likely to
-            // hit an existing use of the same expression.
             try {
-                expr = parseLookupString(expr);
+                expr = await this.parseLookupString(expr);
             } catch (err) {
                 if (err instanceof LookupParseError) {
                     return new Promise((r) => r(new ErrorValue(err)));
@@ -102,6 +96,31 @@ export class CachedLookupContext implements LookupContext {
                 throw err;
             }
         }
-        return this._cache.evaluateExprWithCache(expr, this.entryId);
+        // We always parse it first because this allows us to normalize the expression to make the cache more likely to
+        // hit an existing use of the same expression.
+        return this._evaluateExprWithCache(expr);
+    }
+
+    protected async _evaluateExprWithCache(expr: LookupExpression) {
+        const prefix = (this.entryId ?? "") + ":";
+        // Key is the entry ID, then a colon, then the expression in "standard form"
+        const key = prefix + expr.toString();
+        const cachedValue = this._cache.get(key);
+        if (cachedValue !== undefined) {
+            return cachedValue;
+        }
+        // Evaluate the value and cache the result:
+        let value;
+        try {
+            value = await expr.getValue(this);
+        } catch (err: unknown) {
+            if (err instanceof LookupError) {
+                value = new ErrorValue(err);
+            } else {
+                throw err;
+            }
+        }
+        this._cache.set(key, value);
+        return value;
     }
 }

--- a/backend/neolace/core/lookup/expressions/functions/all-functions.ts
+++ b/backend/neolace/core/lookup/expressions/functions/all-functions.ts
@@ -1,18 +1,6 @@
-import { VNID } from "neolace/deps/vertex-framework.ts";
-import { getPluginsForSite } from "neolace/plugins/loader.ts";
 import * as allExpressions from "../../expressions.ts";
 import { LookupFunction, LookupFunctionClass } from "./base.ts";
 
 export const builtInLookupFunctions = Object.values(allExpressions).filter((expr) =>
     expr.prototype instanceof LookupFunction
 ) as unknown as LookupFunctionClass[];
-
-export async function getAllLookupFunctions(siteId?: VNID): Promise<LookupFunctionClass[]> {
-    const functions = [...builtInLookupFunctions];
-    if (siteId) {
-        for (const _plugin of await getPluginsForSite(siteId)) {
-            // TODO: if the plugin implements a lookup function, push it.
-        }
-    }
-    return functions;
-}

--- a/backend/neolace/core/lookup/expressions/functions/count.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/count.test.ts
@@ -1,28 +1,20 @@
-import { VNID } from "neolace/deps/vertex-framework.ts";
-import { assertEquals, assertRejects, group, setTestIsolation, test } from "neolace/lib/tests.ts";
-import { getGraph } from "neolace/core/graph.ts";
+import { assertEquals, assertRejects, group, setTestIsolation, test, TestLookupContext } from "neolace/lib/tests.ts";
 import { IntegerValue } from "../../values.ts";
 import { Count } from "./count.ts";
 import { LiteralExpression } from "../literal-expr.ts";
 import { LookupEvaluationError } from "../../errors.ts";
-import { LookupExpression } from "../base.ts";
 import { This } from "../this.ts";
 
 group("count.ts", () => {
     const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
-    const evalExpression = (expr: LookupExpression, entryId?: VNID) =>
-        getGraph().then((graph) =>
-            graph.read((tx) => expr.getValue({ tx, siteId, entryId, defaultPageSize: 10n })).then((v) =>
-                v.makeConcrete()
-            )
-        );
     const siteId = defaultData.site.id;
+    const context = new TestLookupContext({ siteId });
 
     test(`It gives an error with non-countable values`, async () => {
         const expression = new Count(new LiteralExpression(new IntegerValue(-30)));
 
         await assertRejects(
-            () => evalExpression(expression),
+            () => context.evaluateExprConcrete(expression),
             LookupEvaluationError,
             `The expression "-30" cannot be counted with count().`,
         );

--- a/backend/neolace/core/lookup/expressions/functions/if.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/if.test.ts
@@ -1,6 +1,5 @@
 import { VNID } from "neolace/deps/vertex-framework.ts";
-import { assertEquals, group, setTestIsolation, test } from "neolace/lib/tests.ts";
-import { getGraph } from "neolace/core/graph.ts";
+import { assertEquals, group, setTestIsolation, test, TestLookupContext } from "neolace/lib/tests.ts";
 import {
     BooleanValue,
     ConcreteValue,
@@ -18,14 +17,9 @@ import { List } from "../list-expr.ts";
 group("if.ts", () => {
     const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
     const siteId = defaultData.site.id;
-    const evalExpression = (expr: LookupExpression, entryId?: VNID) =>
-        getGraph().then((graph) =>
-            graph.read((tx) => expr.getValue({ tx, siteId, entryId, defaultPageSize: 10n })).then((v) =>
-                v.makeConcrete()
-            )
-        );
+    const context = new TestLookupContext({ siteId });
     const assertEvaluatesTo = async (expr: LookupExpression, value: ConcreteValue) =>
-        assertEquals(await evalExpression(expr), value);
+        assertEquals(await context.evaluateExprConcrete(expr), value);
 
     const literal = (value: ConcreteValue) => new LiteralExpression(value);
     const literalTrue = literal(new BooleanValue(true));

--- a/backend/neolace/core/lookup/expressions/functions/related.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/related.test.ts
@@ -1,5 +1,4 @@
-import { assertEquals, group, setTestIsolation, test } from "neolace/lib/tests.ts";
-import { getGraph } from "neolace/core/graph.ts";
+import { assertEquals, group, setTestIsolation, test, TestLookupContext } from "neolace/lib/tests.ts";
 import { AndRelated } from "./related.ts";
 import { AnnotatedValue, EntryValue, IntegerValue, PageValue } from "../../values.ts";
 import { This } from "../this.ts";
@@ -10,20 +9,15 @@ group("andRelated()", () => {
     const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
     const siteId = defaultData.site.id;
     const ponderosaPine = defaultData.entries.ponderosaPine;
+    const context = new TestLookupContext({ siteId, entryId: ponderosaPine.id, defaultPageSize: 15n });
 
     const one = new LiteralExpression(new IntegerValue(1));
     const two = new LiteralExpression(new IntegerValue(2));
 
     test("It can find all entries related to the ponderosa pine (depth = 1)", async () => {
-        // this is the same as this.ancestors().graph()
+        // this is the same as this.andRelated(depth=1)
         const expression = new AndRelated(new This(), { depth: one });
-
-        const graph = await getGraph();
-        const value = await graph.read((tx) =>
-            expression.getValue({ tx, siteId, entryId: ponderosaPine.id, defaultPageSize: 10n }).then((v) =>
-                v.makeConcrete()
-            )
-        );
+        const value = await context.evaluateExprConcrete(expression);
 
         assertEquals(
             value,
@@ -41,7 +35,7 @@ group("andRelated()", () => {
                     }),
                 ],
                 {
-                    pageSize: 10n,
+                    pageSize: 15n,
                     startedAt: 0n,
                     totalCount: 3n,
                     sourceExpression: expression,
@@ -52,15 +46,8 @@ group("andRelated()", () => {
     });
 
     test("It can find all entries related to the ponderosa pine (depth = 2)", async () => {
-        // this is the same as this.ancestors().graph()
         const expression = new AndRelated(new This(), { depth: two });
-
-        const graph = await getGraph();
-        const value = await graph.read((tx) =>
-            expression.getValue({ tx, siteId, entryId: ponderosaPine.id, defaultPageSize: 15n }).then((v) =>
-                v.makeConcrete()
-            )
-        );
+        const value = await context.evaluateExprConcrete(expression);
 
         assertEquals(
             value,

--- a/backend/neolace/core/lookup/expressions/functions/related.ts
+++ b/backend/neolace/core/lookup/expressions/functions/related.ts
@@ -40,7 +40,7 @@ export class AndRelated extends LookupFunctionWithArgs {
         const depth = await this.depthExpr?.getValueAs(IntegerValue, context) ?? new IntegerValue(1);
 
         if (depth.value < 1n || depth.value > 4n) {
-            throw new LookupEvaluationError(`Invalid depth for andRelated(): ${depth}`);
+            throw new LookupEvaluationError(`Invalid depth for andRelated(): ${depth.value}`);
         }
 
         return new LazyEntrySetValue(

--- a/backend/neolace/core/lookup/expressions/functions/reverse.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/reverse.test.ts
@@ -1,6 +1,4 @@
-import { VNID } from "neolace/deps/vertex-framework.ts";
-import { assertEquals, group, setTestIsolation, test } from "neolace/lib/tests.ts";
-import { getGraph } from "neolace/core/graph.ts";
+import { assertEquals, group, setTestIsolation, test, TestLookupContext } from "neolace/lib/tests.ts";
 import {
     InlineMarkdownStringValue,
     IntegerValue,
@@ -10,7 +8,6 @@ import {
     PropertyValue,
 } from "../../values.ts";
 import { ReverseProperty } from "./reverse.ts";
-import { LookupExpression } from "../base.ts";
 import { This } from "../this.ts";
 import { LiteralExpression } from "../literal-expr.ts";
 
@@ -20,12 +17,7 @@ group("reverse.ts", () => {
     const cone = defaultData.entries.cone.id;
     const seedCone = defaultData.entries.seedCone.id;
     const pollenCone = defaultData.entries.pollenCone.id;
-    const evalExpression = (expr: LookupExpression, entryId?: VNID) =>
-        getGraph().then((graph) =>
-            graph.read((tx) =>
-                expr.getValue({ tx, siteId, entryId, defaultPageSize: 10n }).then((v) => v.makeConcrete())
-            )
-        );
+    const context = new TestLookupContext({ siteId });
 
     // Literal expressions referencing some properties in the default PlantDB data set:
     const partIsAPart = new LiteralExpression(new PropertyValue(defaultData.schema.properties._partIsAPart.id));
@@ -39,7 +31,7 @@ group("reverse.ts", () => {
 
     test(`Can reverse a simple IS A relationship property value`, async () => {
         const expression = new ReverseProperty(new This(), { prop: partIsAPart });
-        const value = await evalExpression(expression, cone);
+        const value = await context.evaluateExprConcrete(expression, cone);
         // A "seed cone" and a "pollen cone" are both a "cone", so we should get them
         // by reversing the "IS A" relationship on "cone"
         assertEquals(

--- a/backend/neolace/core/lookup/expressions/functions/slice.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/slice.test.ts
@@ -1,11 +1,9 @@
-import { assertEquals, group, setTestIsolation, test } from "neolace/lib/tests.ts";
-import { getGraph } from "neolace/core/graph.ts";
+import { assertEquals, group, setTestIsolation, test, TestLookupContext } from "neolace/lib/tests.ts";
 import { ConcreteValue, IntegerValue, PageValue, StringValue } from "../../values.ts";
 
 import { Slice } from "./slice.ts";
 import { List } from "../list-expr.ts";
 import { LiteralExpression } from "../literal-expr.ts";
-import { LookupExpression } from "../base.ts";
 
 group("slice.ts", () => {
     // These tests are read-only so don't need isolation, but do use the default plantDB example data:
@@ -13,15 +11,7 @@ group("slice.ts", () => {
     const siteId = defaultData.site.id;
     const ponderosaPine = defaultData.entries.ponderosaPine;
     const int = (v: number) => new LiteralExpression(new IntegerValue(v));
-
-    const evaluate = async (expr: LookupExpression) => {
-        const graph = await getGraph();
-
-        const value = await graph.read((tx) =>
-            expr.getValue({ tx, siteId, entryId: ponderosaPine.id, defaultPageSize: 10n }).then((v) => v.makeConcrete())
-        );
-        return value;
-    };
+    const context = new TestLookupContext({ siteId, entryId: ponderosaPine.id });
 
     group("slice tests with list of ten string values", () => {
         const tenListValues = [
@@ -57,62 +47,62 @@ group("slice.ts", () => {
 
         test("slice(list) without arguments returns the whole list", async () => {
             const expression = new Slice(tenList, {});
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues, { startedAt: 0n });
         });
 
         test("slice(list, start=5)", async () => {
             const expression = new Slice(tenList, { start: int(5) });
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues.slice(5), { startedAt: 5n });
         });
 
         test("slice(list, start=-3)", async () => {
             const expression = new Slice(tenList, { start: int(-3) });
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues.slice(7), { startedAt: 7n });
         });
 
         test("slice(list, start=-30)", async () => {
             const expression = new Slice(tenList, { start: int(-30) });
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues, { startedAt: 0n });
         });
 
         test("slice(list, start=5, size=2)", async () => {
             const expression = new Slice(tenList, { start: int(5), size: int(2) });
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues.slice(5, 7), { startedAt: 5n });
         });
 
         test("slice(list, start=5, end=8)", async () => {
             const expression = new Slice(tenList, { start: int(5), end: int(8) });
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues.slice(5, 8), { startedAt: 5n });
         });
 
         test("slice(list, start=5, end=8, size=2)", async () => {
             // size takes priority over end
             const expression = new Slice(tenList, { start: int(5), end: int(8), size: int(2) });
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues.slice(5, 7), { startedAt: 5n });
         });
 
         test("slice(list, end=500)", async () => {
             const expression = new Slice(tenList, { end: int(500) });
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues, { startedAt: 0n });
         });
 
         test("slice(list, start=3, end=-3)", async () => {
             const expression = new Slice(tenList, { start: int(3), end: int(-3) });
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues.slice(3, 7), { startedAt: 3n });
         });
 
         test("slice(list, end=-3, size=2)", async () => {
             const expression = new Slice(tenList, { end: int(-3), size: int(2) });
-            const value = await evaluate(expression);
+            const value = await context.evaluateExprConcrete(expression);
             check(value, tenListValues.slice(0, 2), { startedAt: 0n });
         });
     });

--- a/backend/neolace/core/lookup/expressions/list-expr.test.ts
+++ b/backend/neolace/core/lookup/expressions/list-expr.test.ts
@@ -1,51 +1,41 @@
-import { VNID } from "neolace/deps/vertex-framework.ts";
-import { assertEquals, group, setTestIsolation, test } from "neolace/lib/tests.ts";
-import { getGraph } from "neolace/core/graph.ts";
+import { assertEquals, group, setTestIsolation, test, TestLookupContext } from "neolace/lib/tests.ts";
 import { IntegerValue, NullValue, PageValue } from "../values.ts";
 import { LiteralExpression } from "./literal-expr.ts";
 import { List } from "./list-expr.ts";
-import { LookupExpression } from "./base.ts";
 import { Count } from "./functions/count.ts";
 
 group("list-expr.ts", () => {
     const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
-    const evalExpression = (expr: LookupExpression, entryId?: VNID) =>
-        getGraph().then((graph) =>
-            graph.read((tx) =>
-                expr.getValue({ tx, siteId, entryId, defaultPageSize: 10n }).then((v) => v.makeConcrete())
-            )
-        );
     const siteId = defaultData.site.id;
+    const context = new TestLookupContext({ siteId });
 
     const Int = (x: number) => new LiteralExpression(new IntegerValue(x));
 
-    group("LiteralExpression", () => {
-        test(`An empty list`, async () => {
-            const expression = new List([]);
-            const value = PageValue.from([], 10n);
+    test(`An empty list`, async () => {
+        const expression = new List([]);
+        const value = PageValue.from([], 10n);
 
-            assertEquals(await evalExpression(expression), value);
-            assertEquals(expression.toString(), "[]");
-        });
-
-        test(`It can hold two integers`, async () => {
-            const expression = new List([Int(15), Int(-30)]);
-            const value = PageValue.from([new IntegerValue(15), new IntegerValue(-30)], 10n);
-
-            assertEquals(await evalExpression(expression), value);
-            assertEquals(expression.toString(), `[15, -30]`);
-        });
-
-        test(`It can be counted`, async () => {
-            const expression = new Count(
-                new List([Int(1), Int(2), new LiteralExpression(new NullValue())]),
-            );
-            const value = new IntegerValue(3);
-
-            assertEquals(await evalExpression(expression), value);
-            assertEquals(expression.toString(), `[1, 2, null].count()`);
-        });
-
-        // TODO test that this can be evaluated to get the count() without evaluating lazy values that it holds
+        assertEquals(await context.evaluateExprConcrete(expression), value);
+        assertEquals(expression.toString(), "[]");
     });
+
+    test(`It can hold two integers`, async () => {
+        const expression = new List([Int(15), Int(-30)]);
+        const value = PageValue.from([new IntegerValue(15), new IntegerValue(-30)], 10n);
+
+        assertEquals(await context.evaluateExprConcrete(expression), value);
+        assertEquals(expression.toString(), `[15, -30]`);
+    });
+
+    test(`It can be counted`, async () => {
+        const expression = new Count(
+            new List([Int(1), Int(2), new LiteralExpression(new NullValue())]),
+        );
+        const value = new IntegerValue(3);
+
+        assertEquals(await context.evaluateExprConcrete(expression), value);
+        assertEquals(expression.toString(), `[1, 2, null].count()`);
+    });
+
+    // TODO test that this can be evaluated to get the count() without evaluating lazy values that it holds
 });

--- a/backend/neolace/core/lookup/expressions/literal-expr.test.ts
+++ b/backend/neolace/core/lookup/expressions/literal-expr.test.ts
@@ -1,50 +1,40 @@
-import { VNID } from "neolace/deps/vertex-framework.ts";
-import { assertEquals, group, setTestIsolation, test } from "neolace/lib/tests.ts";
-import { getGraph } from "neolace/core/graph.ts";
+import { assertEquals, group, setTestIsolation, test, TestLookupContext } from "neolace/lib/tests.ts";
 import { IntegerValue, NullValue, StringValue } from "../values.ts";
 import { LiteralExpression } from "./literal-expr.ts";
-import { LookupExpression } from "./base.ts";
 
 group("literal-expr.ts", () => {
     const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
     const siteId = defaultData.site.id;
-    const evalExpression = (expr: LookupExpression, entryId?: VNID) =>
-        getGraph().then((graph) =>
-            graph.read((tx) =>
-                expr.getValue({ tx, siteId, entryId, defaultPageSize: 10n }).then((v) => v.makeConcrete())
-            )
-        );
+    const context = new TestLookupContext({ siteId });
 
-    group("LiteralExpression", () => {
-        test(`It can hold an integer value and express it as a literal`, async () => {
-            const value = new IntegerValue(-30);
-            const expression = new LiteralExpression(value);
+    test(`It can hold an integer value and express it as a literal`, async () => {
+        const value = new IntegerValue(-30);
+        const expression = new LiteralExpression(value);
 
-            assertEquals(await evalExpression(expression), value);
-            assertEquals(expression.toString(), "-30");
-        });
-
-        test(`It can hold a string value and express it as a literal`, async () => {
-            const value = new StringValue("hello world");
-            const expression = new LiteralExpression(value);
-
-            assertEquals(await evalExpression(expression), value);
-            assertEquals(expression.toString(), `"hello world"`);
-        });
-
-        test(`It can hold a null value and express it as a literal`, async () => {
-            const value = new NullValue();
-            const expression = new LiteralExpression(value);
-
-            assertEquals(await evalExpression(expression), value);
-            assertEquals(expression.toString(), `null`);
-        });
-
-        // test(`It gives an error with non-literal values`, async () => {
-        //     const value = TODO
-        //     const expression = new EntryValue(value);
-
-        //     TODO
-        // });
+        assertEquals(await context.evaluateExpr(expression), value);
+        assertEquals(expression.toString(), "-30");
     });
+
+    test(`It can hold a string value and express it as a literal`, async () => {
+        const value = new StringValue("hello world");
+        const expression = new LiteralExpression(value);
+
+        assertEquals(await context.evaluateExpr(expression), value);
+        assertEquals(expression.toString(), `"hello world"`);
+    });
+
+    test(`It can hold a null value and express it as a literal`, async () => {
+        const value = new NullValue();
+        const expression = new LiteralExpression(value);
+
+        assertEquals(await context.evaluateExpr(expression), value);
+        assertEquals(expression.toString(), `null`);
+    });
+
+    // test(`It gives an error with non-literal values`, async () => {
+    //     const value = TODO
+    //     const expression = new EntryValue(value);
+
+    //     TODO
+    // });
 });

--- a/backend/neolace/core/lookup/expressions/this.test.ts
+++ b/backend/neolace/core/lookup/expressions/this.test.ts
@@ -1,39 +1,30 @@
-import { assertEquals, assertRejects, group, setTestIsolation, test } from "neolace/lib/tests.ts";
-import { getGraph } from "neolace/core/graph.ts";
+import { assertEquals, assertRejects, group, setTestIsolation, test, TestLookupContext } from "neolace/lib/tests.ts";
 import { EntryValue } from "../values.ts";
 import { This } from "./this.ts";
 import { LookupEvaluationError } from "../errors.ts";
 
 group("this.ts", () => {
-    group("this", () => {
-        // These tests are read-only so don't need isolation, but do use the default plantDB example data:
-        const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
-        const siteId = defaultData.site.id;
-        const ponderosaPine = defaultData.entries.ponderosaPine;
+    // These tests are read-only so don't need isolation, but do use the default plantDB example data:
+    const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
+    const siteId = defaultData.site.id;
+    const ponderosaPine = defaultData.entries.ponderosaPine;
+    const context = new TestLookupContext({ siteId, entryId: ponderosaPine.id });
 
-        test("It gives the ID of the current entry in an entry context", async () => {
-            const graph = await getGraph();
-            const expression = new This();
+    test("It gives the ID of the current entry in an entry context", async () => {
+        const expression = new This();
+        const value = await context.evaluateExpr(expression);
 
-            const value = await graph.read((tx) =>
-                expression.getValue({ tx, siteId, entryId: ponderosaPine.id, defaultPageSize: 10n })
-            );
+        assertEquals(value, new EntryValue(ponderosaPine.id));
+    });
 
-            assertEquals(
-                value,
-                new EntryValue(ponderosaPine.id),
-            );
-        });
+    test("It doesn't return a result outside of an entry context", async () => {
+        const expression = new This();
+        const noEntryContext = new TestLookupContext({ siteId, entryId: undefined });
 
-        test("It doesn't return a result outside of an entry context", async () => {
-            const graph = await getGraph();
-            const expression = new This();
-
-            await assertRejects(
-                () => graph.read((tx) => expression.getValue({ tx, siteId, entryId: undefined, defaultPageSize: 10n })),
-                LookupEvaluationError,
-                `The keyword "this" only works in the context of a specific entry.`,
-            );
-        });
+        await assertRejects(
+            () => noEntryContext.evaluateExpr(expression),
+            LookupEvaluationError,
+            `The keyword "this" only works in the context of a specific entry.`,
+        );
     });
 });

--- a/backend/neolace/core/lookup/parse.ts
+++ b/backend/neolace/core/lookup/parse.ts
@@ -7,13 +7,20 @@ import { type LookupFunctionClass } from "./expressions/functions/base.ts";
 import { builtInLookupFunctions } from "./expressions/functions/all-functions.ts";
 
 /**
+ * Parse a lookup expression.
+ *
  * Given a lookup expression as a string like
- *     this.andAncestors()
- * Parse it and return it as a LookupExpression object:
+ *     "this.andAncestors()"
+ * This function will parse it and return it as a LookupExpression object:
  *     new AndAncestors(new This());
+ *
+ * You should generally not use this directly, but rather use LookupContext.parseLookupString() or
+ * parseLookupString.evaluateExpr() since those will load any lookup function plugins that are enabled for the specific
+ * site before calling this method to do the parsing. You can use this directly in tests, however, as long as the tests
+ * don't rely on any plugins.
  */
 export function parseLookupString(lookup: string, withExtraFunctions: LookupFunctionClass[] = []): LookupExpression {
-    // To save time and make development faster, we are cheating with a working but very fake parser.
+    // To save time and make development faster, we are cheating with a working but somewhat simplistic parser.
     // In the future this function should be replaced with a proper parser built using https://chevrotain.io/
 
     lookup = lookup.trim();

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -130,7 +130,6 @@ export function useLookupExpression(expr: string, options: {entryId?: VNID} = {}
         if (expr.trim() === "") {
             // If there is no expression, don't bother hitting the API:
             return {
-                expressionNormalized: "",
                 resultValue: {type: "Null" as const},
                 entryContext: options.entryId,
                 referenceCache: { entries: {}, entryTypes: {}, lookups: [], properties: {} },

--- a/neolace-api/src/content/evaluate-lookup.ts
+++ b/neolace-api/src/content/evaluate-lookup.ts
@@ -1,14 +1,10 @@
-import { Schema, Type, string, vnidString } from "../api-schemas.ts";
+import { Schema, Type, vnidString } from "../api-schemas.ts";
 import { LookupValueSchema } from "./lookup-value.ts";
 import { ReferenceCacheSchema } from "./reference-cache.ts";
 /**
  * Response returned when the "evaluate lookup expression" API endpoint is used to run a lookup on the knowledge base.
  */
  export const EvaluateLookupSchema = Schema({
-    /**
-     * The normalized version of the lookup expression that was requested.
-     */
-    expressionNormalized: string,
     /** The ID of the entry that was used as the context ("this") when evaluating the expression, if any. */
     entryContext: vnidString.strictOptional(),
     resultValue: LookupValueSchema,


### PR DESCRIPTION
This refactors `LookupContext` so that it can be used to parse and evaluate expressions, which will help us consistently parse and evaluate expressions that may use lookup function plugins in the future.

This should generally make the code less repetitive and more consistent.