### PR TITLE
Simplify how annotations are serialized

### DIFF
--- a/backend/neolace/api/site/{siteShortId}/draft/edit-tests.test.ts
+++ b/backend/neolace/api/site/{siteShortId}/draft/edit-tests.test.ts
@@ -105,11 +105,10 @@ group("edit tests", () => {
                 },
             });
             const valueAfterEdit1 = getValue(await getEntry());
-            assert(valueAfterEdit1?.type === "Annotated");
-            assert(valueAfterEdit1.value.type === "String");
-            assertEquals(valueAfterEdit1.value.value, "Jeffrey's pine");
-            assertEquals(valueAfterEdit1.annotations.note, { type: "InlineMarkdownString", value: "" });
-            assertEquals(valueAfterEdit1.annotations.rank, { type: "Integer", value: "1" }); // Is a string since our number type is bigint, which doesn't JSON serialize as Number
+            assert(valueAfterEdit1?.type === "String");
+            assertEquals(valueAfterEdit1.value, "Jeffrey's pine");
+            assertEquals(valueAfterEdit1.annotations?.note, { type: "InlineMarkdownString", value: "" });
+            assertEquals(valueAfterEdit1.annotations?.rank, { type: "Integer", value: "1" }); // Is a string since our number type is bigint, which doesn't JSON serialize as Number
 
             // Now we give it a second value:
 
@@ -127,16 +126,14 @@ group("edit tests", () => {
             assert(valueAfterEdit2?.type === "Page");
             assertEquals(valueAfterEdit2.values.length, 2);
             // The first value is unchanged:
-            assert(valueAfterEdit2.values[0].type === "Annotated");
-            assert(valueAfterEdit2.values[0].value.type === "String");
-            assertEquals(valueAfterEdit2.values[0].value.value, "Jeffrey's pine");
+            assert(valueAfterEdit2.values[0].type === "String");
+            assertEquals(valueAfterEdit2.values[0].value, "Jeffrey's pine");
             // The second value is added:
-            assert(valueAfterEdit2.values[1].type === "Annotated");
-            assert(valueAfterEdit2.values[1].value.type === "String");
-            assertEquals(valueAfterEdit2.values[1].value.value, "pin de Jeffrey");
+            assert(valueAfterEdit2.values[1].type === "String");
+            assertEquals(valueAfterEdit2.values[1].value, "pin de Jeffrey");
             // The second value has a rank of 2 automatically assigned:
-            assertEquals(valueAfterEdit2.values[1].annotations.rank, { type: "Integer", value: "2" });
-            assertEquals(valueAfterEdit2.values[1].annotations.note, {
+            assertEquals(valueAfterEdit2.values[1].annotations?.rank, { type: "Integer", value: "2" });
+            assertEquals(valueAfterEdit2.values[1].annotations?.note, {
                 type: "InlineMarkdownString",
                 value: "(French)",
             });
@@ -190,10 +187,10 @@ group("edit tests", () => {
 
             // At first, the property is "Pinus ponderosa":
             const beforeValue = getValue(before);
-            assert(beforeValue?.type === "Annotated");
+            assert(beforeValue?.type === "InlineMarkdownString");
             // Because "Scientific name" gets italicized automatically, we have to read the "plainValue":
-            assertEquals(beforeValue.annotations.plainValue, { type: "String", value: "Pinus ponderosa" });
-            assert(beforeValue.annotations.propertyFactId.type === "String");
+            assertEquals(beforeValue.annotations?.plainValue, { type: "String", value: "Pinus ponderosa" });
+            assert(beforeValue.annotations?.propertyFactId.type === "String");
             const propertyFactId = VNID(beforeValue.annotations.propertyFactId.value);
 
             // Now we change the property value:
@@ -206,8 +203,8 @@ group("edit tests", () => {
             });
 
             const afterValue = getValue(await getEntry());
-            assert(afterValue?.type === "Annotated");
-            assertEquals(afterValue.annotations.plainValue, { type: "String", value: "New value" });
+            assert(afterValue?.type === "InlineMarkdownString");
+            assertEquals(afterValue.annotations?.plainValue, { type: "String", value: "New value" });
         });
 
         test("We can update an entry's relationship property value", async () => {
@@ -225,10 +222,10 @@ group("edit tests", () => {
 
             // At first, the property is "Pinus ponderosa":
             const beforeValue = getValue(before);
-            assert(beforeValue?.type === "Annotated");
+            assert(beforeValue?.type === "Entry");
             // The original value of "Parent Genus" is "genus Pinus":
-            assertEquals(beforeValue.value, { type: "Entry", id: defaultData.entries.genusPinus.id });
-            assert(beforeValue.annotations.propertyFactId.type === "String");
+            assertEquals(beforeValue.id, defaultData.entries.genusPinus.id);
+            assert(beforeValue.annotations?.propertyFactId.type === "String");
             const propertyFactId = VNID(beforeValue.annotations.propertyFactId.value);
 
             // Now we change the property value:
@@ -242,13 +239,13 @@ group("edit tests", () => {
             });
 
             const afterValue = getValue(await getEntry());
-            assert(afterValue?.type === "Annotated");
-            assertEquals(afterValue.value, { type: "Entry", id: newGenusId });
+            assert(afterValue?.type === "Entry");
+            assertEquals(afterValue.id, newGenusId);
             // And to test that the "direct relationships" were updated correctly, we use ancestors(), because the
             // ancestors() function doesn't check PropertyFact entries but rather uses the direct IS_A relationships.
             const result = await client.evaluateLookupExpression(`[[/entry/${entryId}]].ancestors().first()`);
-            assert(result.resultValue.type === "Annotated");
-            assertEquals(result.resultValue.value, { type: "Entry", id: newGenusId });
+            assert(result.resultValue.type === "Entry");
+            assertEquals(result.resultValue.id, newGenusId);
         });
     });
 
@@ -265,15 +262,14 @@ group("edit tests", () => {
             );
 
             //  check the property exists
-            assert(propertyFact?.value.type === "Annotated");
-            assert(propertyFact?.value.value.type === "Entry");
-            assertEquals(propertyFact?.value.value.id, defaultData.entries.familyCupressaceae.id);
+            assert(propertyFact?.value.type === "Entry");
+            assertEquals(propertyFact?.value.id, defaultData.entries.familyCupressaceae.id);
 
             // now delete the property
             await doEdit(client, {
                 code: api.DeletePropertyValue.code,
                 data: {
-                    propertyFactId: VNID((propertyFact.value.annotations.propertyFactId as api.StringValue).value),
+                    propertyFactId: VNID((propertyFact.value.annotations?.propertyFactId as api.StringValue).value),
                 },
             });
 

--- a/backend/neolace/api/site/{siteShortId}/entry/{entryId}/_helpers.ts
+++ b/backend/neolace/api/site/{siteShortId}/entry/{entryId}/_helpers.ts
@@ -159,13 +159,7 @@ export async function getEntry(
                 }
             }
             const serializedValue = value.toJSON();
-            if (
-                (serializedValue.type === "Page" && serializedValue.values.length === 0) ||
-                (
-                    serializedValue.type === "Annotated" && serializedValue.value.type === "Page" &&
-                    serializedValue.value.values.length === 0
-                )
-            ) {
+            if (serializedValue.type === "Page" && serializedValue.values.length === 0) {
                 // This property value is just an empty result set. Hide it from the result.
                 continue;
             }

--- a/backend/neolace/api/site/{siteShortId}/entry/{entryId}/index.test.ts
+++ b/backend/neolace/api/site/{siteShortId}/entry/{entryId}/index.test.ts
@@ -68,11 +68,8 @@ group("entry/index.test.ts", () => {
                     {
                         propertyId: defaultData.schema.properties._parentGenus.id,
                         value: {
-                            type: "Annotated",
-                            value: {
-                                type: "Entry",
-                                id: defaultData.entries.genusPinus.id,
-                            },
+                            type: "Entry",
+                            id: defaultData.entries.genusPinus.id,
                             annotations: {
                                 ...defaultAnnotations,
                             },
@@ -82,8 +79,8 @@ group("entry/index.test.ts", () => {
                     {
                         propertyId: defaultData.schema.properties._propScientificName.id,
                         value: {
-                            type: "Annotated",
-                            value: { value: "*Pinus ponderosa*", type: "InlineMarkdownString" },
+                            type: "InlineMarkdownString",
+                            value: "*Pinus ponderosa*",
                             annotations: {
                                 ...defaultAnnotations,
                                 plainValue: { value: "Pinus ponderosa", type: "String" },
@@ -94,56 +91,38 @@ group("entry/index.test.ts", () => {
                     {
                         propertyId: defaultData.schema.properties._taxonomy.id,
                         value: {
-                            type: "Annotated",
-                            value: {
-                                type: "Page",
-                                startedAt: 0,
-                                totalCount: 5,
-                                pageSize: 5,
-                                values: [
-                                    {
-                                        type: "Annotated",
-                                        value: {
-                                            type: "Entry",
-                                            id: defaultData.entries.genusPinus.id,
-                                        },
-                                        annotations: { distance: { type: "Integer", value: "1" } },
-                                    },
-                                    {
-                                        type: "Annotated",
-                                        value: {
-                                            type: "Entry",
-                                            id: defaultData.entries.familyPinaceae.id,
-                                        },
-                                        annotations: { distance: { type: "Integer", value: "2" } },
-                                    },
-                                    {
-                                        type: "Annotated",
-                                        value: {
-                                            type: "Entry",
-                                            id: defaultData.entries.orderPinales.id,
-                                        },
-                                        annotations: { distance: { type: "Integer", value: "3" } },
-                                    },
-                                    {
-                                        type: "Annotated",
-                                        value: {
-                                            type: "Entry",
-                                            id: defaultData.entries.classPinopsida.id,
-                                        },
-                                        annotations: { distance: { type: "Integer", value: "4" } },
-                                    },
-                                    {
-                                        type: "Annotated",
-                                        value: {
-                                            type: "Entry",
-                                            id: defaultData.entries.divisionTracheophyta.id,
-                                        },
-                                        annotations: { distance: { type: "Integer", value: "5" } },
-                                    },
-                                ],
-                                source: { expr: "this.ancestors()", entryId: ponderosaPine.id },
-                            },
+                            type: "Page",
+                            startedAt: 0,
+                            totalCount: 5,
+                            pageSize: 5,
+                            values: [
+                                {
+                                    type: "Entry",
+                                    id: defaultData.entries.genusPinus.id,
+                                    annotations: { distance: { type: "Integer", value: "1" } },
+                                },
+                                {
+                                    type: "Entry",
+                                    id: defaultData.entries.familyPinaceae.id,
+                                    annotations: { distance: { type: "Integer", value: "2" } },
+                                },
+                                {
+                                    type: "Entry",
+                                    id: defaultData.entries.orderPinales.id,
+                                    annotations: { distance: { type: "Integer", value: "3" } },
+                                },
+                                {
+                                    type: "Entry",
+                                    id: defaultData.entries.classPinopsida.id,
+                                    annotations: { distance: { type: "Integer", value: "4" } },
+                                },
+                                {
+                                    type: "Entry",
+                                    id: defaultData.entries.divisionTracheophyta.id,
+                                    annotations: { distance: { type: "Integer", value: "5" } },
+                                },
+                            ],
+                            source: { expr: "this.ancestors()", entryId: ponderosaPine.id },
                             annotations: {
                                 // This value came from the default on the entry type, not the specific entry itself.
                                 source: { type: "String", value: "Default" },
@@ -160,11 +139,8 @@ group("entry/index.test.ts", () => {
                             totalCount: 2,
                             values: [
                                 {
-                                    type: "Annotated",
-                                    value: {
-                                        type: "Entry",
-                                        id: defaultData.entries.pollenCone.id,
-                                    },
+                                    type: "Entry",
+                                    id: defaultData.entries.pollenCone.id,
                                     annotations: {
                                         ...defaultAnnotations,
                                         slot: { type: "String", value: "pollen-cone" },
@@ -172,11 +148,8 @@ group("entry/index.test.ts", () => {
                                     },
                                 },
                                 {
-                                    type: "Annotated",
-                                    value: {
-                                        type: "Entry",
-                                        id: defaultData.entries.seedCone.id,
-                                    },
+                                    type: "Entry",
+                                    id: defaultData.entries.seedCone.id,
                                     annotations: {
                                         ...defaultAnnotations,
                                         slot: { type: "String", value: "seed-cone" },
@@ -195,39 +168,35 @@ group("entry/index.test.ts", () => {
                     {
                         propertyId: defaultData.schema.properties._relImages.id,
                         value: {
-                            type: "Annotated",
-                            value: {
-                                pageSize: 5,
-                                startedAt: 0,
-                                totalCount: 1,
-                                type: "Page",
-                                values: [
-                                    {
-                                        type: "Image",
-                                        format: "thumb",
-                                        entryId: defaultData.entries.imgPonderosaTrunk.id,
-                                        altText: defaultData.entries.imgPonderosaTrunk.name,
-                                        blurHash: "LCDu}B~VNu9Z0LxGNH9u$zjYWCt7",
-                                        contentType: "image/webp",
-                                        imageUrl: (result.propertiesSummary?.find((x) =>
-                                            x.propertyId === defaultData.schema.properties._relImages.id
-                                            // deno-lint-ignore no-explicit-any
-                                        )?.value as any).value.values[0].imageUrl,
-                                        link: {
-                                            type: "Entry",
-                                            id: defaultData.entries.imgPonderosaTrunk.id,
-                                        },
-                                        size: 1581898,
-                                        sizing: "cover",
-                                        width: 3504,
-                                        height: 2336,
+                            pageSize: 5,
+                            startedAt: 0,
+                            totalCount: 1,
+                            type: "Page",
+                            values: [
+                                {
+                                    type: "Image",
+                                    format: "thumb",
+                                    entryId: defaultData.entries.imgPonderosaTrunk.id,
+                                    altText: defaultData.entries.imgPonderosaTrunk.name,
+                                    blurHash: "LCDu}B~VNu9Z0LxGNH9u$zjYWCt7",
+                                    contentType: "image/webp",
+                                    imageUrl: ((result.propertiesSummary?.find((x) =>
+                                        x.propertyId === defaultData.schema.properties._relImages.id
+                                    )?.value as api.PageValue).values[0] as api.ImageValue).imageUrl,
+                                    link: {
+                                        type: "Entry",
+                                        id: defaultData.entries.imgPonderosaTrunk.id,
                                     },
-                                ],
-                                source: {
-                                    expr:
-                                        `this.andDescendants().reverse(prop=[[/prop/${defaultData.schema.properties._imgRelTo.id}]])`,
-                                    entryId: ponderosaPine.id,
+                                    size: 1581898,
+                                    sizing: "cover",
+                                    width: 3504,
+                                    height: 2336,
                                 },
+                            ],
+                            source: {
+                                expr:
+                                    `this.andDescendants().reverse(prop=[[/prop/${defaultData.schema.properties._imgRelTo.id}]])`,
+                                entryId: ponderosaPine.id,
                             },
                             annotations: {
                                 source: { type: "String", value: "Default" },
@@ -238,11 +207,8 @@ group("entry/index.test.ts", () => {
                     {
                         propertyId: defaultData.schema.properties._propWikidataQID.id,
                         value: {
-                            type: "Annotated",
-                            value: {
-                                type: "InlineMarkdownString",
-                                value: "[Q460523](https://www.wikidata.org/wiki/Q460523)",
-                            },
+                            type: "InlineMarkdownString",
+                            value: "[Q460523](https://www.wikidata.org/wiki/Q460523)",
                             annotations: {
                                 ...defaultAnnotations,
                                 plainValue: { type: "String", value: "Q460523" },

--- a/backend/neolace/core/entry/reference-cache.ts
+++ b/backend/neolace/core/entry/reference-cache.ts
@@ -164,6 +164,11 @@ export class ReferenceCache {
      * IDs that are present in the value (recursively). Adds to the set(s) passed as a parameter
      */
     public extractLookupReferences(value: api.AnyLookupValue, args: { currentEntryId?: VNID }) {
+        if (value.annotations) {
+            for (const annotatedValue of Object.values(value.annotations)) {
+                this.extractLookupReferences(annotatedValue, args);
+            }
+        }
         switch (value.type) {
             case "Page": {
                 value.values.forEach((v) => this.extractLookupReferences(v, args));
@@ -172,12 +177,12 @@ export class ReferenceCache {
                 }
                 return;
             }
-            case "Annotated": {
-                this.extractLookupReferences(value.value, args);
-                return;
-            }
             case "Entry": {
                 this._entryIdsUsed.add(value.id);
+                return;
+            }
+            case "EntryType": {
+                // TODO: store the entry type?
                 return;
             }
             case "Image": {
@@ -201,6 +206,7 @@ export class ReferenceCache {
                 }
                 return;
             }
+            case "Boolean":
             case "Integer":
             case "String":
             case "Date":

--- a/backend/neolace/core/lookup/values/AnnotatedValue.ts
+++ b/backend/neolace/core/lookup/values/AnnotatedValue.ts
@@ -1,4 +1,5 @@
-import { VNID } from "neolace/deps/vertex-framework.ts";
+import type { VNID } from "neolace/deps/vertex-framework.ts";
+import type * as api from "neolace/deps/neolace-api.ts";
 import { LookupContext } from "../context.ts";
 import { ClassOf, ConcreteValue, LookupValue } from "./base.ts";
 import { EntryValue } from "./EntryValue.ts";
@@ -31,11 +32,11 @@ export class AnnotatedValue extends ConcreteValue {
     }
 
     protected serialize() {
-        const annotations: Record<string, unknown> = {};
+        const annotations: Record<string, api.AnyLookupValue> = {};
         for (const key in this.annotations) {
             annotations[key] = this.annotations[key].toJSON();
         }
-        return { value: this.value.toJSON(), annotations };
+        return { ...this.value.toJSON(), annotations };
     }
 
     protected override doCastTo(

--- a/backend/neolace/core/lookup/values/BooleanValue.ts
+++ b/backend/neolace/core/lookup/values/BooleanValue.ts
@@ -1,3 +1,4 @@
+import type * as api from "neolace/deps/neolace-api.ts";
 import { ConcreteValue } from "./base.ts";
 
 /**
@@ -19,7 +20,7 @@ export class BooleanValue extends ConcreteValue {
         return this.value ? "true" : "false";
     }
 
-    protected serialize() {
-        return { value: this.value };
+    protected serialize(): api.BooleanValue {
+        return { type: "Boolean" as const, value: this.value };
     }
 }

--- a/backend/neolace/core/lookup/values/DateValue.ts
+++ b/backend/neolace/core/lookup/values/DateValue.ts
@@ -50,7 +50,7 @@ export class DateValue extends ConcreteValue {
     }
 
     protected serialize() {
-        return { value: this.asIsoString() };
+        return { type: "Date" as const, value: this.asIsoString() };
     }
 
     protected override doCastTo(newType: ClassOf<LookupValue>, _context: LookupContext): LookupValue | undefined {

--- a/backend/neolace/core/lookup/values/EntryTypeValue.ts
+++ b/backend/neolace/core/lookup/values/EntryTypeValue.ts
@@ -21,6 +21,6 @@ export class EntryTypeValue extends ConcreteValue implements IHasLiteralExpressi
     }
 
     protected serialize() {
-        return { id: this.id };
+        return { type: "EntryType" as const, id: this.id };
     }
 }

--- a/backend/neolace/core/lookup/values/EntryValue.ts
+++ b/backend/neolace/core/lookup/values/EntryValue.ts
@@ -39,6 +39,6 @@ export class EntryValue extends ConcreteValue implements IHasLiteralExpression {
     }
 
     protected serialize() {
-        return { id: this.id };
+        return { type: "Entry" as const, id: this.id };
     }
 }

--- a/backend/neolace/core/lookup/values/ErrorValue.ts
+++ b/backend/neolace/core/lookup/values/ErrorValue.ts
@@ -20,6 +20,6 @@ export class ErrorValue extends ConcreteValue {
     }
 
     protected serialize() {
-        return { errorClass: this.error.constructor.name, message: this.error.message };
+        return { type: "Error" as const, errorClass: this.error.constructor.name, message: this.error.message };
     }
 }

--- a/backend/neolace/core/lookup/values/FileValue.ts
+++ b/backend/neolace/core/lookup/values/FileValue.ts
@@ -18,8 +18,9 @@ export class FileValue extends ConcreteValue {
         return undefined; // There is no literal expression for a file
     }
 
-    protected serialize(): Omit<api.FileValue, "type"> {
+    protected serialize(): api.FileValue {
         return {
+            type: "File",
             filename: this.filename,
             url: this.url,
             contentType: this.contentType,

--- a/backend/neolace/core/lookup/values/GraphValue.ts
+++ b/backend/neolace/core/lookup/values/GraphValue.ts
@@ -27,8 +27,9 @@ export class GraphValue extends ConcreteValue {
         return undefined; // There is no literal expression for a graph
     }
 
-    protected serialize(): Omit<api.GraphValue, "type"> {
+    protected serialize(): api.GraphValue {
         return {
+            type: "Graph",
             entries: this.entries,
             rels: this.rels,
         };

--- a/backend/neolace/core/lookup/values/ImageValue.ts
+++ b/backend/neolace/core/lookup/values/ImageValue.ts
@@ -39,8 +39,9 @@ export class ImageValue extends ConcreteValue {
         return undefined; // There is no literal expression for an image
     }
 
-    protected serialize(): Omit<api.ImageValue, "type"> {
+    protected serialize(): api.ImageValue {
         return {
+            type: "Image",
             entryId: this.data.entryId,
             altText: this.data.altText,
             caption: this.data.caption?.toJSON() as api.InlineMarkdownString | api.StringValue | undefined,

--- a/backend/neolace/core/lookup/values/InlineMarkdownStringValue.ts
+++ b/backend/neolace/core/lookup/values/InlineMarkdownStringValue.ts
@@ -25,7 +25,7 @@ export class InlineMarkdownStringValue extends ConcreteValue implements IHasLite
     }
 
     protected serialize() {
-        return { value: this.value };
+        return { type: "InlineMarkdownString" as const, value: this.value };
     }
 
     protected override doCastTo(newType: ClassOf<LookupValue>, _context: LookupContext): LookupValue | undefined {

--- a/backend/neolace/core/lookup/values/IntegerValue.ts
+++ b/backend/neolace/core/lookup/values/IntegerValue.ts
@@ -25,7 +25,7 @@ export class IntegerValue extends ConcreteValue {
     protected serialize() {
         // Unfortunately JavaScript cannot serialize BigInt to JSON numbers (even though JSON numbers can have
         // arbitrary digits), so we have to serialize it as a string.
-        return { value: String(this.value) };
+        return { type: "Integer" as const, value: String(this.value) };
     }
 
     protected override doCastTo(newType: ClassOf<LookupValue>, _context: LookupContext): LookupValue | undefined {

--- a/backend/neolace/core/lookup/values/NullValue.ts
+++ b/backend/neolace/core/lookup/values/NullValue.ts
@@ -15,7 +15,7 @@ export class NullValue extends ConcreteValue implements IHasLiteralExpression {
     }
 
     protected serialize() {
-        return {};
+        return { type: "Null" as const };
     }
 
     protected override doCastTo(newType: ClassOf<LookupValue>, _context: LookupContext): LookupValue | undefined {

--- a/backend/neolace/core/lookup/values/PageValue.ts
+++ b/backend/neolace/core/lookup/values/PageValue.ts
@@ -40,7 +40,8 @@ export class PageValue<T extends ConcreteValue> extends ConcreteValue {
     }
 
     protected serialize() {
-        const v: Omit<api.PageValue, "type"> = {
+        const v: api.PageValue = {
+            type: "Page",
             values: this.values.map((v) => v.toJSON()),
             startedAt: Number(this.startedAt),
             pageSize: Number(this.pageSize),

--- a/backend/neolace/core/lookup/values/PropertyValue.ts
+++ b/backend/neolace/core/lookup/values/PropertyValue.ts
@@ -21,6 +21,6 @@ export class PropertyValue extends ConcreteValue implements IHasLiteralExpressio
     }
 
     protected serialize() {
-        return { id: this.id };
+        return { type: "Property" as const, id: this.id };
     }
 }

--- a/backend/neolace/core/lookup/values/StringValue.ts
+++ b/backend/neolace/core/lookup/values/StringValue.ts
@@ -34,7 +34,7 @@ export class StringValue extends ConcreteValue implements IHasLiteralExpression,
     }
 
     protected serialize() {
-        return { value: this.value };
+        return { type: "String" as const, value: this.value };
     }
 
     protected override doCastTo(newType: ClassOf<LookupValue>, _context: LookupContext): LookupValue | undefined {

--- a/backend/neolace/core/lookup/values/base.ts
+++ b/backend/neolace/core/lookup/values/base.ts
@@ -87,14 +87,10 @@ export abstract class ConcreteValue extends LookupValue {
     static readonly isLazy = false;
 
     /** Return fields other than 'type' to be included in this value when serialized as a JSON object. */
-    protected abstract serialize(): Omit<api.AnyLookupValue, "type">;
+    protected abstract serialize(): api.AnyLookupValue;
     public toJSON(): api.AnyLookupValue {
         if (!this.constructor.name.endsWith("Value")) throw new Error("Invalid value class name");
-        return {
-            // "type" is the name of the ____Value class without the "Value" part
-            type: this.constructor.name.substr(0, this.constructor.name.length - 5),
-            ...this.serialize(),
-        } as api.AnyLookupValue;
+        return this.serialize();
     }
 
     public makeConcrete(): Promise<ConcreteValue> {

--- a/frontend/components/LookupEvaluator.tsx
+++ b/frontend/components/LookupEvaluator.tsx
@@ -68,11 +68,7 @@ export const LookupEvaluatorWithPagination: React.FunctionComponent<PropsWithPag
     // SWR will ensure that the inner <LookupEvaluator> doesn't send additional API requests for the same lookup expression.
     const {result, error} = useLookupExpression(props.expr, {entryId: props.mdtContext.entryId});
 
-    const pageData = (
-        result?.resultValue.type === "Page" ? result.resultValue :
-        result?.resultValue.type === "Annotated" && result.resultValue.value.type === "Page" ? result.resultValue.value :
-        undefined
-    );
+    const pageData = result?.resultValue.type === "Page" ? result.resultValue : undefined;
 
     if (pageData) {
         const numValuesPerPage = pageData.pageSize;

--- a/frontend/components/LookupValue.tsx
+++ b/frontend/components/LookupValue.tsx
@@ -38,6 +38,17 @@ export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) =>
         return <p>[ERROR INVALID VALUE, NO TYPE INFORMATION]</p>;  // Doesn't need i18n, internal error message shouldn't be seen
     }
 
+    if (value.annotations?.note && value.annotations.note.type === "InlineMarkdownString" && value.annotations.note.value !== "") {
+        const {note, ...annotationsWithoutNote} = value.annotations;
+        const valueWithoutNote = {...value, annotations: annotationsWithoutNote};
+        return <>
+            <LookupValue value={valueWithoutNote} mdtContext={props.mdtContext} hideShowMoreLink={props.hideShowMoreLink} />
+            <HoverClickNote>
+                <p className="text-sm"><InlineMDT mdt={note.value} context={props.mdtContext} /></p>
+            </HoverClickNote>
+        </>;
+    }
+
     switch (value.type) {
         case "Page": {
 
@@ -64,14 +75,11 @@ export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) =>
             // FIXME: Temporary hack, replace with transform+annotate to give display hint https://app.clickup.com/t/23uvf0q
             if (site.shortId === "cams" && listValues.length > 2) {
                 const firstValue = value.values[0];
-                if (firstValue.type === "Annotated") {
-                    const innerValue = firstValue.value;
-                    if (innerValue.type === "Entry") {
-                        if (props.mdtContext.refCache.entries[innerValue.id]?.entryType.id === "_42oypp3JCf4wpJRru0El17") {
-                            return <ul>
-                                {listValues.map((v, idx) => <li key={idx}>{v}</li>)}
-                            </ul>;
-                        }
+                if (firstValue.type === "Entry") {
+                    if (props.mdtContext.refCache.entries[firstValue.id]?.entryType.id === "_42oypp3JCf4wpJRru0El17") {
+                        return <ul>
+                            {listValues.map((v, idx) => <li key={idx}>{v}</li>)}
+                        </ul>;
                     }
                 }
             }
@@ -112,6 +120,14 @@ export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) =>
                 {attribs => <span {...attribs}>{prop.name}</span>}
             </Tooltip>
         }
+        case "Boolean":
+            return <>{
+                value.value
+                ? <FormattedMessage id="common.lookup-expression.true" defaultMessage="True"/>
+                : <FormattedMessage id="common.lookup-expression.false" defaultMessage="False"/>
+            }</>
+        case "Integer":
+            return <>{value.value}</>
         case "String":
             // Temporary special case hack for the TechNotes hompage until we support video:
             if (value.value === "$TN_HOME_VIDEO$") {
@@ -132,16 +148,6 @@ export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) =>
                     values={{errorType: value.errorClass, errorMessage: value.message}}
                 />
             </ErrorMessage>
-        case "Annotated":
-            if (value.annotations.note && value.annotations.note.type === "InlineMarkdownString" && value.annotations.note.value !== "") {
-                return <>
-                    <LookupValue value={value.value} mdtContext={props.mdtContext} />
-                    <HoverClickNote>
-                        <p className="text-sm"><InlineMDT mdt={value.annotations.note.value} context={props.mdtContext} /></p>
-                    </HoverClickNote>
-                </>;
-            }
-            return <LookupValue value={value.value} mdtContext={props.mdtContext} hideShowMoreLink={props.hideShowMoreLink} />
         case "Null":
             return <></>;
         default: {

--- a/neolace-api/src/content/lookup-value.ts
+++ b/neolace-api/src/content/lookup-value.ts
@@ -5,6 +5,7 @@ import { ImageSizingMode } from "./Entry.ts";
 /** A "lookup value" / query result / computed fact that has been serialized to JSON */
 export interface LookupValue {
     type: string;
+    annotations?: Record<string, AnyLookupValue>
 }
 
 export interface PageValue extends LookupValue {
@@ -23,6 +24,11 @@ export interface ListValue extends LookupValue {
 
 export interface EntryValue extends LookupValue {
     type: "Entry";
+    id: VNID;
+}
+
+export interface EntryTypeValue extends LookupValue {
+    type: "EntryType";
     id: VNID;
 }
 
@@ -83,10 +89,9 @@ export interface ImageValue extends LookupValue {
     sizing: ImageSizingMode,
 }
 
-export interface AnnotatedValue extends LookupValue {
-    type: "Annotated";
-    value: AnyLookupValue;
-    annotations: Record<string, AnyLookupValue>;
+export interface BooleanValue extends LookupValue {
+    type: "Boolean";
+    value: boolean;
 }
 
 export interface IntegerValue extends LookupValue {
@@ -124,11 +129,12 @@ export interface ErrorValue extends LookupValue {
 export type AnyLookupValue = (
     | PageValue
     | EntryValue
+    | EntryTypeValue
     | FileValue
     | PropertyValue
     | GraphValue
     | ImageValue
-    | AnnotatedValue
+    | BooleanValue
     | IntegerValue
     | DateValue
     | StringValue


### PR DESCRIPTION
Instead of wrapping a value in `{type: "Annotated", value: {...}, annotations: {...}}` this just adds `annotations: {...}` on to the existing value object. Much simpler to work with!