### PR TITLE
Major Upgrade to Neo4j 4.4

### DIFF
--- a/backend/import_map.json
+++ b/backend/import_map.json
@@ -1,6 +1,6 @@
 {
     "imports": {
         "neolace/": "./neolace/",
-        "std/": "https://deno.land/std@0.145.0/"
+        "std/": "https://deno.land/std@0.146.0/"
     }
 }

--- a/backend/neolace/deps/vertex-framework.ts
+++ b/backend/neolace/deps/vertex-framework.ts
@@ -1,3 +1,3 @@
 // For local dev:
 // export * from "../../../../vertex-framework/vertex/index.ts";
-export * from "https://raw.githubusercontent.com/neolace-dev/vertex-framework/ff54b15b89e866caf4d189ff2cb96308cd85a785/vertex/index.ts";
+export * from "https://raw.githubusercontent.com/neolace-dev/vertex-framework/307fb1c99108251449fffc1c3b2a2c3d165b990f/vertex/index.ts";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ version: '3'
 x-service-templates:
   neo4j:
     &neo4j-defaults
-    image: neo4j:4.3
+    image: neo4j:4.4.8
     environment:
       # Set default password to "neolace"
       NEO4J_AUTH: neo4j/neolace

--- a/docs/import_map.json
+++ b/docs/import_map.json
@@ -1,6 +1,6 @@
 {
     "imports": {
         "neolace/": "../backend/neolace/",
-        "std/": "https://deno.land/std@0.145.0/"
+        "std/": "https://deno.land/std@0.146.0/"
     }
 }

--- a/neolace-api/neolace-admin.ts
+++ b/neolace-api/neolace-admin.ts
@@ -9,12 +9,12 @@
  * it is recommended that you create a wrapper script for each realm that you administer.
  */
 import * as api from "./src/index.ts";
-import * as log from "https://deno.land/std@0.135.0/log/mod.ts";
-// import { parse as parseArgs } from "https://deno.land/std@0.135.0/flags/mod.ts";
-import { parse as parseYaml, stringify as stringifyYaml, } from "https://deno.land/std@0.135.0/encoding/yaml.ts";
-import { readAll } from "https://deno.land/std@0.135.0/streams/conversion.ts";
+import * as log from "https://deno.land/std@0.146.0/log/mod.ts";
+// import { parse as parseArgs } from "https://deno.land/std@0.146.0/flags/mod.ts";
+import { parse as parseYaml, stringify as stringifyYaml, } from "https://deno.land/std@0.146.0/encoding/yaml.ts";
+import { readAll } from "https://deno.land/std@0.146.0/streams/conversion.ts";
 import { VNID } from "https://raw.githubusercontent.com/neolace-dev/vertex-framework/f5e5a577518307d609ded1e16aa7f1fe1cb02b64/vertex/lib/types/vnid.ts";
-import { assertEquals } from "https://deno.land/std@0.135.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.146.0/testing/asserts.ts";
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Usage instructions

--- a/neolace-api/src/edit/consolidate-edits.test.ts
+++ b/neolace-api/src/edit/consolidate-edits.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.145.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.146.0/testing/asserts.ts";
 import { VNID } from "../types.ts";
 import {
     type AnyEdit,

--- a/neolace-api/src/markdown-mdt-test-helpers.ts
+++ b/neolace-api/src/markdown-mdt-test-helpers.ts
@@ -1,4 +1,4 @@
-export { assertEquals } from "https://deno.land/std@0.135.0/testing/asserts.ts";
+export { assertEquals } from "https://deno.land/std@0.146.0/testing/asserts.ts";
 import type { AnyInlineNode, InlineNode, TopLevelNode } from "./markdown-mdt-ast.ts";
 import type { Node, RootNode } from "./markdown-mdt.ts";
 


### PR DESCRIPTION
This bumps the version of Vertex Framework used so that we're running Neo4j 4.4. It also bumps to version 0.146.0 of the Deno std library, to match what's used by Vertex Framework and the Deno driver.