### PR TITLE
Remove use of null values in string fields

### DIFF
--- a/backend/neolace/api/site/find.test.ts
+++ b/backend/neolace/api/site/find.test.ts
@@ -14,7 +14,7 @@ group("find.ts", () => {
                 shortId: "plantdb",
                 domain: "plantdb.local.neolace.net",
                 url: "http://plantdb.local.neolace.net:4445",
-                description: null,
+                description: "",
                 footerMD: "Powered by [Neolace](https://www.neolace.com/).",
                 frontendConfig: {
                     headerLinks: [

--- a/backend/neolace/api/site/{siteShortId}/draft/edit-tests.test.ts
+++ b/backend/neolace/api/site/{siteShortId}/draft/edit-tests.test.ts
@@ -13,7 +13,7 @@ import { VNID } from "neolace/deps/vertex-framework.ts";
 
 /** Helper function to apply edits for this test case, using an API client. */
 async function doEdit(client: api.NeolaceApiClient, ...edits: api.AnyEdit[]): Promise<void> {
-    const draftDefaults = { title: "A Test Draft", description: null };
+    const draftDefaults = { title: "A Test Draft" };
     return client.createDraft({
         ...draftDefaults,
         edits,

--- a/backend/neolace/api/site/{siteShortId}/draft/index.test.ts
+++ b/backend/neolace/api/site/{siteShortId}/draft/index.test.ts
@@ -26,7 +26,6 @@ group("index.ts", () => {
                 const client = await getClient(defaultData.users.admin, defaultData.site.shortId);
                 const result = await client.createDraft({
                     title: "A Test Draft",
-                    description: null,
                     edits: [],
                 });
                 assert(isVNID(result.id));
@@ -45,7 +44,6 @@ group("index.ts", () => {
 
                 const createDraftArgs: api.CreateDraftData = {
                     title: "A Test Draft",
-                    description: null,
                     edits: [],
                 };
 
@@ -91,7 +89,6 @@ group("index.ts", () => {
 
                 const createDraftArgs: api.CreateDraftData = {
                     title: "A Test Draft",
-                    description: null,
                     edits: [],
                 };
 
@@ -109,7 +106,7 @@ group("index.ts", () => {
             test("cannot create a draft with an empty title", async () => {
                 const client = await getClient(defaultData.users.admin, defaultData.site.shortId);
                 const err = await assertRejects(
-                    () => client.createDraft({ title: "", description: null, edits: [] }),
+                    () => client.createDraft({ title: "", edits: [] }),
                 );
                 assertInstanceOf(err, api.InvalidFieldValue);
                 assertEquals(err.fieldErrors[0].fieldPath, "title");
@@ -121,7 +118,6 @@ group("index.ts", () => {
                 const err = await assertRejects(() =>
                     client.createDraft({
                         title: "Invalid edits",
-                        description: null,
                         edits: [
                             // deno-lint-ignore no-explicit-any
                             { code: "FOOBAR", data: {} } as any,
@@ -134,7 +130,6 @@ group("index.ts", () => {
                 const err2 = await assertRejects(() =>
                     client.createDraft({
                         title: "Invalid edits",
-                        description: null,
                         edits: [
                             {
                                 code: api.CreateEntry.code,
@@ -152,7 +147,6 @@ group("index.ts", () => {
         group("A draft with schema edits", () => {
             const createDraftWithSchemaEdits: api.CreateDraftData = {
                 title: "A Test Draft",
-                description: null,
                 edits: [
                     {
                         code: api.CreateEntryType.code,
@@ -247,7 +241,6 @@ group("index.ts", () => {
         group("A draft with content edits", () => {
             const createDraftWithContentEdits: api.CreateDraftData = {
                 title: "A Test Draft",
-                description: null,
                 edits: [
                     {
                         code: api.CreateEntry.code,

--- a/backend/neolace/api/site/{siteShortId}/schema/index.test.ts
+++ b/backend/neolace/api/site/{siteShortId}/schema/index.test.ts
@@ -62,7 +62,7 @@ group("schema/index.ts", () => {
                     _ETSOFTWARE: {
                         id: VNID("_ETSOFTWARE"),
                         description: "",
-                        friendlyIdPrefix: null,
+                        friendlyIdPrefix: "",
                         name: "Software",
                         enabledFeatures: {},
                         color: api.EntryTypeColor.Default,

--- a/backend/neolace/api/user/index.test.ts
+++ b/backend/neolace/api/user/index.test.ts
@@ -22,7 +22,7 @@ group("api/user/index.ts", () => {
             const result = await client.registerHumanUser({ emailToken });
 
             assertEquals(result.userData.isBot, false);
-            assertEquals(result.userData.fullName, null);
+            assertEquals(result.userData.fullName, "");
             assertEquals(result.userData.username, "jamie456");
         });
 

--- a/backend/neolace/core/Site.ts
+++ b/backend/neolace/core/Site.ts
@@ -94,11 +94,11 @@ export class Site extends VNodeType {
          * Description: a public description of the website, displayed to users in a few different places as well as to
          * search engines.
          */
-        description: Field.NullOr.String.Check(check.string.max(5_000)),
+        description: Field.String.Check(check.string.max(5_000)),
         /**
          * Markdown text for the home page. This defines the content of the home page.
          */
-        homePageMD: Field.NullOr.String.Check(check.string.max(100_000)),
+        homePageMD: Field.String.Check(check.string.max(100_000)),
         /**
          * Markdown text for the footer, shown on all pages.
          */
@@ -347,8 +347,8 @@ export const CreateSite = defineAction({
                 name: ${data.name},
                 slugId: ${data.slugId},
                 siteCode: ${siteCode},
-                description: ${data.description || null},
-                homePageMD: ${data.homePageMD || null},
+                description: ${data.description || ""},
+                homePageMD: ${data.homePageMD || ""},
                 footerMD: ${data.footerMD || ""},
                 domain: ${data.domain},
                 accessMode: ${data.accessMode ?? AccessMode.PublicContributions},

--- a/backend/neolace/core/User.ts
+++ b/backend/neolace/core/User.ts
@@ -21,7 +21,7 @@ export class User extends VNodeType {
         // slugId: starts with "user-", then follows a unique code. Can be changed any time.
         slugId: Field.Slug,
         // Optional full name
-        fullName: Field.NullOr.String.Check(check.string.max(100)),
+        fullName: Field.String.Check(check.string.max(100)),
     };
 
     static async validate(dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
@@ -145,7 +145,7 @@ export const CreateUser = defineAction({
                 authnId: ${BigInt(data.authnId)},
                 email: ${data.email},
                 slugId: ${User.slugIdPrefix + username},
-                fullName: ${data.fullName || null}
+                fullName: ${data.fullName || ""}
             })
         `.RETURN({}));
         return {
@@ -183,7 +183,7 @@ export const CreateBot = defineAction({
                 id: ${vnid},
                 slugId: ${User.slugIdPrefix + data.username},
                 authToken: ${authToken},
-                fullName: ${data.fullName || null}
+                fullName: ${data.fullName || ""}
             })-[:${BotUser.rel.OWNED_BY} {inheritPermissions: ${data.inheritPermissions ?? false}}]->(owner)
         `.RETURN({}));
         return {

--- a/backend/neolace/core/edit/ApplyEdits.ts
+++ b/backend/neolace/core/edit/ApplyEdits.ts
@@ -380,6 +380,7 @@ export const ApplyEdits = defineAction({
                         SET et += ${{
                         name: edit.data.name,
                         description: "",
+                        friendlyIdPrefix: "",
                         color: EntryTypeColor.Default,
                         abbreviation: "",
                     }}
@@ -401,9 +402,6 @@ export const ApplyEdits = defineAction({
                     await tx.queryOne(C`
                         MATCH (et:${EntryType} {id: ${edit.data.id}})-[:${EntryType.rel.FOR_SITE}]->(site:${Site} {id: ${siteId}})
                         SET et += ${changes}
-                        // Temporary code while we have old data in the database with these values NULL:
-                        SET et.color = coalesce(et.color, "")
-                        SET et.abbreviation = coalesce(et.abbreviation, "")
                     `.RETURN({}));
                     modifiedNodes.add(edit.data.id);
                     break;
@@ -454,6 +452,7 @@ export const ApplyEdits = defineAction({
                         editNoteMD: "",
                         displayAs: "",
                         default: "",
+                        valueConstraint: "",
                         enableSlots: false,
                     }}
                     `.RETURN({}));

--- a/backend/neolace/core/edit/Draft.ts
+++ b/backend/neolace/core/edit/Draft.ts
@@ -107,7 +107,7 @@ export class Draft extends VNodeType {
     static readonly properties = {
         ...VNodeType.properties,
         title: Field.String.Check(check.string.min(1).max(1_000)),
-        description: Field.NullOr.String,
+        description: Field.String,
         created: Field.DateTime,
         status: Field.Int.Check(check.Schema.enum(DraftStatus)),
     };
@@ -284,7 +284,7 @@ export const CreateDraft = defineAction({
         authorId: VNID;
         edits: EditList;
         title: string;
-        description: string | null;
+        description?: string;
     },
     resultData: {} as { id: VNID },
     apply: async (tx, data) => {
@@ -295,7 +295,7 @@ export const CreateDraft = defineAction({
             MATCH (author:${User} {id: ${data.authorId}})
             CREATE (draft:${Draft} {id: ${id}})
             SET draft.title = ${data.title}
-            SET draft.description = ${data.description}
+            SET draft.description = ${data.description ?? ""}
             SET draft.status = ${DraftStatus.Open}
             SET draft.created = datetime()
             CREATE (draft)-[:${Draft.rel.FOR_SITE}]->(site)

--- a/backend/neolace/core/entry/properties.ts
+++ b/backend/neolace/core/entry/properties.ts
@@ -187,7 +187,7 @@ export async function getEntryProperties<TC extends true | undefined = undefined
                 id: Field.VNID,
                 name: Field.String,
                 importance: Field.Int,
-                default: Field.NullOr.String,
+                default: Field.String,
                 displayAs: Field.String,
             }),
             facts: Field.List(Field.Record({

--- a/backend/neolace/core/objstore/DataFile.ts
+++ b/backend/neolace/core/objstore/DataFile.ts
@@ -43,7 +43,7 @@ export class DataFile extends VNodeType {
          * Any data in this field must be something that can be derived purely from the file contents; in other words,
          * this is data about what the file is, not about how it is being used.
          */
-        metadataJSON: Field.NullOr.String,
+        metadataJSON: Field.String,
     };
 
     static derivedProperties = this.hasDerivedProperties({
@@ -52,7 +52,7 @@ export class DataFile extends VNodeType {
     });
 
     static async validate(dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
-        if (dbObject.metadataJSON !== null) {
+        if (dbObject.metadataJSON) {
             try {
                 const data = JSON.parse(dbObject.metadataJSON);
                 FileMetadataSchema(data); // Validate the metadata against the schema

--- a/backend/neolace/core/schema/EntryType.ts
+++ b/backend/neolace/core/schema/EntryType.ts
@@ -1,6 +1,6 @@
 import * as check from "neolace/deps/computed-types.ts";
 import * as api from "neolace/deps/neolace-api.ts";
-import { C, Field, VirtualPropType, VNodeType } from "neolace/deps/vertex-framework.ts";
+import { C, Field, validateValue, VirtualPropType, VNodeType } from "neolace/deps/vertex-framework.ts";
 import { Site } from "neolace/core/Site.ts";
 
 import { EnabledFeature } from "neolace/core/entry/features/EnabledFeature.ts";
@@ -15,9 +15,13 @@ export class EntryType extends VNodeType {
         /** The name of this entry type */
         name: Field.String,
         /** Description: Short, rich text summary of the entry type  */
-        description: Field.NullOr.String.Check(check.string.trim().max(5_000)),
-        /** FriendlyId prefix for entries of this type. Can be an empty string */
-        friendlyIdPrefix: Field.NullOr.Slug,
+        description: Field.String.Check(check.string.trim().max(5_000)),
+        /** FriendlyId prefix for entries of this type. */
+        friendlyIdPrefix: Field.String.Check((value) => {
+            // This is really a Field.Slug but Field.Slug doesn't allow empty strings, so we have to do this to
+            // enforce slug validation but also allow empty strings:
+            return value === "" ? "" : validateValue(Field.Slug, value);
+        }),
         /** Color to represent this entry type */
         color: Field.String.Check(check.Schema.enum(api.EntryTypeColor)),
         /** One or two letters used to represent this entry as an abbreviation */

--- a/backend/neolace/core/schema/Property.ts
+++ b/backend/neolace/core/schema/Property.ts
@@ -34,7 +34,7 @@ export class Property extends VNodeType {
          * A lookup expression (usually an "x expression") that defines what values are allowed.
          * This property is ignored if mode is "Auto".
          */
-        valueConstraint: Field.NullOr.String,
+        valueConstraint: Field.String,
         /**
          * The default value for this property, if none is set on the specific entry or its parents.
          * This can be a lookup expression.

--- a/backend/neolace/core/schema/schema.test.ts
+++ b/backend/neolace/core/schema/schema.test.ts
@@ -43,7 +43,7 @@ group("schema.ts", () => {
                         id,
                         name,
                         description: "",
-                        friendlyIdPrefix: null,
+                        friendlyIdPrefix: "",
                         enabledFeatures: {},
                         color: EntryTypeColor.Default,
                         abbreviation: "",

--- a/neolace-api/src/content/Entry.ts
+++ b/neolace-api/src/content/Entry.ts
@@ -1,4 +1,4 @@
-import { Schema, Type, string, vnidString, nullable, array, number, Validator } from "../api-schemas.ts";
+import { Schema, Type, string, vnidString, array, number, Validator } from "../api-schemas.ts";
 import { LookupValueSchema } from "./lookup-value.ts";
 import { ReferenceCacheSchema } from "./reference-cache.ts";
 
@@ -94,7 +94,7 @@ export type EntryFeaturesData = Type<typeof EntryFeaturesSchema>;
 export const BaseEntrySchema = Schema({
     id: vnidString,
     name: string,
-    description: nullable(string),
+    description: string,
     friendlyId: string,
     entryType: Schema({
         id: vnidString,

--- a/neolace-api/src/edit/Draft.ts
+++ b/neolace-api/src/edit/Draft.ts
@@ -1,4 +1,4 @@
-import { Schema, Type, string, vnidString, nullable, array, DateType, object, } from "../api-schemas.ts";
+import { Schema, Type, string, vnidString, array, DateType, object, } from "../api-schemas.ts";
 import type { AnyEdit } from "./AnyEdit.ts";
 import { EditChangeType } from "./Edit.ts";
 
@@ -22,7 +22,7 @@ export const CreateEditSchema = Schema({code: string, data: object}).transform(e
  */
 export const CreateDraftSchema = Schema({
     title: string,
-    description: nullable(string),
+    description: string.strictOptional(),
     edits: array.of(CreateEditSchema),
 });
 export type CreateDraftData = Type<typeof CreateDraftSchema>;
@@ -39,9 +39,9 @@ export type DraftEditData = Type<typeof DraftEditSchema>;
 
 export const DraftSchema = Schema({
     id: vnidString,
-    author: Schema({username: string, fullName: nullable(string)}),
+    author: Schema({username: string, fullName: string}),
     title: string,
-    description: nullable(string),
+    description: string,
     status: Schema.enum(DraftStatus),
     created: DateType,
     edits: array.of(DraftEditSchema).strictOptional(),

--- a/neolace-api/src/schema/SchemaEdit.ts
+++ b/neolace-api/src/schema/SchemaEdit.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import { nullable, vnidString, Schema, string, array, Type, number } from "../api-schemas.ts";
+import { vnidString, Schema, string, array, Type, number } from "../api-schemas.ts";
 import { boolean, SchemaValidatorFunction } from "../deps/computed-types.ts";
 import { Edit, EditChangeType, EditType } from "../edit/Edit.ts";
 import { SiteSchemaData, PropertyType, PropertyMode, EntryTypeColor } from "./SiteSchemaData.ts";
@@ -33,8 +33,8 @@ export const CreateEntryType = SchemaEditType({
                 [data.id]: {
                     id: data.id,
                     name: data.name,
-                    description: null,
-                    friendlyIdPrefix: null,
+                    description: "",
+                    friendlyIdPrefix: "",
                     enabledFeatures: {},
                     color: EntryTypeColor.Default,
                     abbreviation: "",
@@ -53,8 +53,8 @@ export const UpdateEntryType = SchemaEditType({
     dataSchema: Schema({
         id: vnidString,
         name: string.strictOptional(),
-        description: nullable(string).strictOptional(),
-        friendlyIdPrefix: nullable(string).strictOptional(),
+        description: string.strictOptional(),
+        friendlyIdPrefix: string.strictOptional(),
         color: Schema.enum(EntryTypeColor).strictOptional(),
         abbreviation: string.min(0).max(2).strictOptional(),
     }),
@@ -190,17 +190,19 @@ export const UpdateProperty = SchemaEditType({
 
         // Booleans
         for (const field of ["inheritable", "enableSlots"] as const) {
-            if (data[field] !== undefined) {
-                (newProp as any)[field] = data[field];
+            const value = data[field];
+            if (value !== undefined) {
+                newProp[field] = value;
             }
         }
 
         for (const field of ["valueConstraint", "default", "standardURL", "editNoteMD", "displayAs"] as const) {
-            if (data[field] !== undefined) {
-                if (data[field] === "") {
+            const value = data[field];
+            if (value !== undefined) {
+                if (value === "") {
                     newProp[field] = undefined;
                 } else {
-                    newProp[field] = data[field];
+                    newProp[field] = value;
                 }
             }
         }

--- a/neolace-api/src/schema/SiteSchemaData.ts
+++ b/neolace-api/src/schema/SiteSchemaData.ts
@@ -1,4 +1,4 @@
-import { Schema, Type, string, number, vnidString, nullable, array, boolean, Record, } from "../api-schemas.ts";
+import { Schema, Type, string, number, vnidString, array, boolean, Record, } from "../api-schemas.ts";
 
 /** The available color options for each entry */
 export enum EntryTypeColor {
@@ -42,9 +42,9 @@ export const EntryTypeSchema = Schema({
     id: vnidString,
     /** Name of this entry type, e.g. "Note", "Task", "Contact", "License", etc. Doesn't need to be unique. */
     name: string,
-    description: nullable(string),
+    description: string,
     /** FriendlyId prefix for entries of this type; if NULL then FriendlyIds are not used. */
-    friendlyIdPrefix: nullable(string),
+    friendlyIdPrefix: string,
     /** Color to represent this entry type */
     color: Schema.enum(EntryTypeColor),
     /** One or two letters used to represent this entry as an abbreviation */

--- a/neolace-api/src/site/Site.ts
+++ b/neolace-api/src/site/Site.ts
@@ -1,4 +1,4 @@
-import { Schema, Type, string, nullable, array, boolean, Record, number, object, } from "../api-schemas.ts";
+import { Schema, Type, string, array, boolean, Record, number, object } from "../api-schemas.ts";
 import { ReferenceCacheSchema } from "../content/reference-cache.ts";
 import { VNID } from "../types.ts";
 
@@ -35,7 +35,7 @@ export const SiteDetailsSchema = Schema({
      * Description: a public description of the website, displayed to users in a few different places as well as to
      * search engines.
      */
-    description: nullable(string),
+    description: string,
     /**
      * The short ID is a slug-like string identifier that uniquely identifies this site and must be used to specify the
      * site in any site-specific API requests.

--- a/neolace-api/src/user.ts
+++ b/neolace-api/src/user.ts
@@ -1,4 +1,4 @@
-import { Schema, string, nullable, boolean, normalString, object } from "./api-schemas.ts";
+import { Schema, string, boolean, normalString, object } from "./api-schemas.ts";
 
 export interface PasswordlessLoginResponse {
     /** Determines whether or not the user's passwordless login request succeeded */
@@ -9,13 +9,13 @@ export const UserDataResponse = Schema.either(
     {
         isBot: boolean.equals(false),
         username: normalString,
-        fullName: nullable(normalString),
+        fullName: normalString,
     },
     {
         isBot: boolean.equals(true),
         ownedByUsername: string,
         username: normalString,
-        fullName: nullable(normalString),
+        fullName: normalString,
     }
 );
 


### PR DESCRIPTION
A lot of things are easier and less confusing if we avoid the use of Neo4j properties / Vertex fields which can be either NULL or Strings. Since we recently made a ton of breaking changes, now is a good time to fix this throughout the app.