### PR TITLE
Bump to Drash 2.7.0 - one small step closer to streaming file uploads

### DIFF
--- a/backend/neolace/api/log-middleware.ts
+++ b/backend/neolace/api/log-middleware.ts
@@ -1,4 +1,5 @@
 import * as log from "std/log/mod.ts";
+import type { ConnInfo } from "std/http/server.ts";
 import { Drash } from "./mod.ts";
 
 export class NeolaceLogService extends Drash.Service {
@@ -18,9 +19,10 @@ export class NeolaceErrorLogger extends Drash.ErrorHandler {
         error: Drash.Errors.HttpError,
         request: Request,
         response: Drash.Response,
+        connInfo: ConnInfo,
     ): Promise<void> {
         // First adjust the response as per the normal base class handling:
-        super.catch(error, request, response);
+        super.catch(error, request, response, connInfo);
         // Then log the error message:
         const parsedUrl = new URL(request.url);
         const msg = `${request.method} ${parsedUrl.pathname} -> ${response.status}: ${error.name}: ${error.message}`;

--- a/backend/neolace/deps/drash.ts
+++ b/backend/neolace/deps/drash.ts
@@ -1,4 +1,4 @@
 /**
  * Drash is a REST microframework for Deno's HTTP server with zero 3rd party dependencies.
  */
-export * as Drash from "https://deno.land/x/drash@v2.6.0/mod.ts";
+export * as Drash from "https://deno.land/x/drash@v2.7.0/mod.ts";


### PR DESCRIPTION
Also nice because this Drash uses the same std. lib. version as our Neo4j driver and Vertex Framework. Reduces dependencies by 10.