### PR TITLE
fix: getting an auto property lookup without 'this' set gave an error

### DIFF
--- a/backend/neolace/core/lookup/expressions/functions/get.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/get.test.ts
@@ -71,11 +71,11 @@ group("get.ts", () => {
     });
 
     group("get() - value property, single entry, multiple values", () => {
-        // TODO
+        // TODO: implement this
     });
 
     group("get() - value property, multiple entries", () => {
-        // TODO
+        // TODO: implement this
     });
 
     group("get() - auto property", () => {
@@ -96,6 +96,18 @@ group("get.ts", () => {
                     sourceExpressionEntryId: defaultData.entries.genusThuja.id,
                 }),
             );
+        });
+        test(`Can retrieve an automatically-computed reverse relationship property value without 'this' being set`, async () => {
+            // Thuja.get(prop=parentGenus) when 'this' is not set should be equal to
+            // this.get(prop=parentGenus)  when 'this' is Thuja.
+            const expression1 = new GetProperty(
+                new LiteralExpression(new EntryValue(defaultData.entries.genusThuja.id)),
+                { prop: genusSpecies }, // This property in turn evalutes 'this.reverse(prop=prop("_parentGenus"))'
+            );
+            const expression2 = new GetProperty(new This(), { prop: genusSpecies });
+            const value1 = await context.evaluateExprConcrete(expression1, undefined);
+            const value2 = await context.evaluateExprConcrete(expression2, defaultData.entries.genusThuja.id);
+            assertEquals(value1, value2);
         });
     });
 


### PR DESCRIPTION
[This](http://technotes.local.neolace.net:5555/lookup?e=entry(%22_5GDsp3jxMTJ1liBePo9sgT%22).andDescendants().reverse(prop%3Dprop(%22_TNHASPART%22))) was working:

![Screen Shot 2022-07-22 at 9 50 25 AM](https://user-images.githubusercontent.com/945577/180486820-0ee537dd-a1bc-4989-acb8-6e2b968a8adb.png)

But [this query](http://technotes.local.neolace.net:5555/lookup?e=entry(%22_5GDsp3jxMTJ1liBePo9sgT%22).get(prop%3Dprop(%22_TNUSEDIN%22))), which should be equivalent, was not:

![Screen Shot 2022-07-22 at 9 51 10 AM](https://user-images.githubusercontent.com/945577/180486940-5cd677ca-3f20-4f24-bdcb-dead270c0743.png)

This fixes the bug.