### PR TITLE
More accurate "source expression" values

### DIFF
--- a/backend/neolace/api/site/{siteShortId}/entry/{entryId}/index.test.ts
+++ b/backend/neolace/api/site/{siteShortId}/entry/{entryId}/index.test.ts
@@ -122,7 +122,11 @@ group("entry/index.test.ts", () => {
                                     annotations: { distance: { type: "Integer", value: "5" } },
                                 },
                             ],
-                            source: { expr: "this.ancestors()", entryId: ponderosaPine.id },
+                            source: {
+                                expr:
+                                    `entry("${ponderosaPine.id}").get(prop=prop("${defaultData.schema.properties._taxonomy.id}"))`,
+                                entryId: ponderosaPine.id,
+                            },
                             annotations: {
                                 // This value came from the default on the entry type, not the specific entry itself.
                                 source: { type: "String", value: "Default" },
@@ -159,7 +163,8 @@ group("entry/index.test.ts", () => {
                                 },
                             ],
                             source: {
-                                expr: `this.get(prop=prop("${defaultData.schema.properties._hasPart.id}"))`,
+                                expr:
+                                    `entry("${ponderosaPine.id}").get(prop=prop("${defaultData.schema.properties._hasPart.id}"))`,
                                 entryId: ponderosaPine.id,
                             },
                         },
@@ -195,7 +200,7 @@ group("entry/index.test.ts", () => {
                             ],
                             source: {
                                 expr:
-                                    `this.andDescendants().reverse(prop=prop("${defaultData.schema.properties._imgRelTo.id}"))`,
+                                    `entry("${ponderosaPine.id}").get(prop=prop("${defaultData.schema.properties._relImages.id}"))`,
                                 entryId: ponderosaPine.id,
                             },
                             annotations: {

--- a/backend/neolace/api/site/{siteShortId}/lookup.test.ts
+++ b/backend/neolace/api/site/{siteShortId}/lookup.test.ts
@@ -26,8 +26,9 @@ group("lookup.ts", () => {
     test("It can evaluate an AUTO relationship property and return a reference cache with details of each entry", async () => {
         const client = await getClient(defaultData.users.admin, defaultData.site.shortId);
 
+        const expr = `this.get(prop=prop("${defaultData.schema.properties._relImages.id}"))`;
         const result = await client.evaluateLookupExpression(
-            `this.get(prop=prop("${defaultData.schema.properties._relImages.id}"))`,
+            expr,
             { entryKey: defaultData.entries.ponderosaPine.friendlyId },
         );
 
@@ -53,10 +54,7 @@ group("lookup.ts", () => {
                     height: 2336,
                 },
             ],
-            source: {
-                expr: `this.andDescendants().reverse(prop=prop("${defaultData.schema.properties._imgRelTo.id}"))`,
-                entryId: defaultData.entries.ponderosaPine.id,
-            },
+            source: { expr, entryId: defaultData.entries.ponderosaPine.id },
         });
         assertEquals(
             result.referenceCache.entries[defaultData.entries.imgPonderosaTrunk.id]?.name,

--- a/backend/neolace/core/entry/properties.ts
+++ b/backend/neolace/core/entry/properties.ts
@@ -167,7 +167,6 @@ export async function getEntryProperties<TC extends true | undefined = undefined
             MATCH (prop)-[:${Property.rel.APPLIES_TO_TYPE}]->(entryType)
                 WHERE
                     ${options.specificPropertyId ? C`prop.id = ${options.specificPropertyId} AND` : C``}
-                    // TODO: use NULL or "" but not both
                     prop.default <> ""
                     AND prop.rank <= ${maxRank}
                     AND NOT exists((entry)-[:${Entry.rel.IS_A}*0..50]->(:${Entry})-[:PROP_FACT]->(:${PropertyFact})-[:${PropertyFact.rel.FOR_PROP}]->(prop))

--- a/backend/neolace/core/lookup/expressions/functions/base.ts
+++ b/backend/neolace/core/lookup/expressions/functions/base.ts
@@ -2,6 +2,8 @@ import { LookupExpression } from "../base.ts";
 import { LookupEvaluationError, LookupParseError } from "../../errors.ts";
 import { This } from "../this.ts";
 import { List } from "../list-expr.ts";
+import { LiteralExpression } from "../../expressions.ts";
+import { EntryTypeValue, EntryValue, PropertyValue } from "../../values.ts";
 
 /**
  * A lookup expression that is a function, like count(), first(), or if(...)
@@ -74,7 +76,12 @@ export abstract class LookupFunctionOneArg extends LookupFunction {
         if (
             this.firstArg instanceof This ||
             this.firstArg instanceof LookupFunction ||
-            this.firstArg instanceof List
+            this.firstArg instanceof List ||
+            this.firstArg instanceof LiteralExpression && (
+                    this.firstArg.value instanceof EntryValue ||
+                    this.firstArg.value instanceof PropertyValue ||
+                    this.firstArg.value instanceof EntryTypeValue
+                )
         ) {
             return `${this.firstArg.toString()}.${this.functionName}()`;
         }

--- a/backend/neolace/core/lookup/expressions/functions/basicSearch.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/basicSearch.test.ts
@@ -37,7 +37,13 @@ group("basicSearch.ts", () => {
                 new EntryValue(defaultData.entries.japaneseWhitePine.id),
                 new EntryValue(defaultData.entries.jeffreyPine.id),
                 new EntryValue(defaultData.entries.pinyonPine.id),
-            ], { pageSize: 5n, startedAt: 0n, totalCount: 9n, sourceExpression: expr }),
+            ], {
+                pageSize: 5n,
+                startedAt: 0n,
+                totalCount: 9n,
+                sourceExpression: expr,
+                sourceExpressionEntryId: undefined,
+            }),
         );
     });
 
@@ -53,7 +59,13 @@ group("basicSearch.ts", () => {
                 new EntryValue(defaultData.entries.japaneseWhitePine.id), // friendlyId: "s-pinus-parviflora"
                 new EntryValue(defaultData.entries.ponderosaPine.id), // friendlyId: "s-pinus-ponderosa"
                 new EntryValue(defaultData.entries.stonePine.id), // friendlyId: "s-pinus-pinea"
-            ], { pageSize: 5n, startedAt: 0n, totalCount: 3n, sourceExpression: expr }),
+            ], {
+                pageSize: 5n,
+                startedAt: 0n,
+                totalCount: 3n,
+                sourceExpression: expr,
+                sourceExpressionEntryId: undefined,
+            }),
         );
     });
 
@@ -68,7 +80,13 @@ group("basicSearch.ts", () => {
                 // These are currently the only two properties with "name" in their property name:
                 new PropertyValue(defaultData.schema.properties._propOtherNames.id),
                 new PropertyValue(defaultData.schema.properties._propScientificName.id),
-            ], { pageSize: 5n, startedAt: 0n, totalCount: 2n, sourceExpression: expr }),
+            ], {
+                pageSize: 5n,
+                startedAt: 0n,
+                totalCount: 2n,
+                sourceExpression: expr,
+                sourceExpressionEntryId: undefined,
+            }),
         );
     });
 
@@ -83,7 +101,13 @@ group("basicSearch.ts", () => {
                 // In this case, we match both an entry type and a property:
                 new EntryTypeValue(defaultData.schema.entryTypes._ETSPECIES.id),
                 new PropertyValue(defaultData.schema.properties._genusSpecies.id),
-            ], { pageSize: 5n, startedAt: 0n, totalCount: 2n, sourceExpression: expr }),
+            ], {
+                pageSize: 5n,
+                startedAt: 0n,
+                totalCount: 2n,
+                sourceExpression: expr,
+                sourceExpressionEntryId: undefined,
+            }),
         );
     });
 
@@ -140,7 +164,13 @@ group("basicSearch.ts - permissions", () => {
                         // In this case, we match both an entry type and a property:
                         new EntryTypeValue(defaultData.schema.entryTypes._ETSPECIES.id),
                         new PropertyValue(defaultData.schema.properties._genusSpecies.id),
-                    ], { pageSize: 5n, startedAt: 0n, totalCount: 2n, sourceExpression: expression }),
+                    ], {
+                        pageSize: 5n,
+                        startedAt: 0n,
+                        totalCount: 2n,
+                        sourceExpression: expression,
+                        sourceExpressionEntryId: undefined,
+                    }),
                 );
             }
         }
@@ -176,7 +206,13 @@ group("basicSearch.ts - permissions", () => {
                         new EntryValue(defaultData.entries.orderPinales.id),
                         new EntryValue(defaultData.entries.genusPinus.id),
                         // Not matched due to permissions: "pinyonPine", "familyPinaceae", etc.
-                    ], { pageSize: 5n, startedAt: 0n, totalCount: 2n, sourceExpression: expression }),
+                    ], {
+                        pageSize: 5n,
+                        startedAt: 0n,
+                        totalCount: 2n,
+                        sourceExpression: expression,
+                        sourceExpressionEntryId: undefined,
+                    }),
                 );
             }
         }

--- a/backend/neolace/core/lookup/expressions/functions/files.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/files.test.ts
@@ -141,7 +141,13 @@ group("files.ts", () => {
                         "application/pdf",
                         secondPdf.size,
                     ),
-                ], { startedAt: 0n, pageSize: 10n, totalCount: 2n, sourceExpression: expression }),
+                ], {
+                    startedAt: 0n,
+                    pageSize: 10n,
+                    totalCount: 2n,
+                    sourceExpression: expression,
+                    sourceExpressionEntryId: undefined,
+                }),
             );
         });
 
@@ -199,7 +205,13 @@ group("files.ts", () => {
 
         assertEquals(
             await context.evaluateExprConcrete(expression),
-            new PageValue([], { startedAt: 0n, pageSize: 10n, totalCount: 0n, sourceExpression: expression }),
+            new PageValue([], {
+                startedAt: 0n,
+                pageSize: 10n,
+                totalCount: 0n,
+                sourceExpression: expression,
+                sourceExpressionEntryId: undefined,
+            }),
         );
     });
 

--- a/backend/neolace/core/lookup/expressions/functions/get.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/get.test.ts
@@ -22,7 +22,6 @@ import {
 import { GetProperty } from "./get.ts";
 import { This } from "../this.ts";
 import { LiteralExpression } from "../literal-expr.ts";
-import { ReverseProperty } from "./reverse.ts";
 import { AccessMode, UpdateSite } from "neolace/core/Site.ts";
 import { corePerm } from "neolace/core/permissions/permissions.ts";
 import { Always, EntryTypesCondition, PermissionGrant } from "neolace/core/permissions/grant.ts";
@@ -44,7 +43,6 @@ group("get.ts", () => {
     const partIsAPart = makeProp(defaultData.schema.properties._partIsAPart.id);
     const hasPart = makeProp(defaultData.schema.properties._hasPart.id);
     const genusSpecies = makeProp(defaultData.schema.properties._genusSpecies.id);
-    const parentGenus = makeProp(defaultData.schema.properties._parentGenus.id);
 
     // When retrieving the entry values from a relationship property, they are "annotated" with data like this:
     const defaultAnnotations = {
@@ -90,9 +88,7 @@ group("get.ts", () => {
                     pageSize: 10n,
                     startedAt: 0n,
                     totalCount: 1n,
-                    // Note that in this case, sourceExpression is not this.get(prop=...), but rather this.reverse(...)
-                    // since that's the "real" lookup expression being used here.
-                    sourceExpression: new ReverseProperty(new This(), { prop: parentGenus }),
+                    sourceExpression: expression,
                     sourceExpressionEntryId: defaultData.entries.genusThuja.id,
                 }),
             );
@@ -107,7 +103,11 @@ group("get.ts", () => {
             const expression2 = new GetProperty(new This(), { prop: genusSpecies });
             const value1 = await context.evaluateExprConcrete(expression1, undefined);
             const value2 = await context.evaluateExprConcrete(expression2, defaultData.entries.genusThuja.id);
-            assertEquals(value1, value2);
+            assertInstanceOf(value1, PageValue);
+            assertInstanceOf(value2, PageValue);
+            assertEquals(value1.values, value2.values);
+            assertEquals(value1.sourceExpression, expression1);
+            assertEquals(value2.sourceExpression, expression2);
         });
     });
 

--- a/backend/neolace/core/lookup/expressions/list-expr.ts
+++ b/backend/neolace/core/lookup/expressions/list-expr.ts
@@ -16,7 +16,7 @@ export class List extends LookupExpression {
         this.items = items;
     }
 
-    public async getValue(context: LookupContext) {
+    public async getValue(context: LookupContext): Promise<LazyIterableValue> {
         // We return a lazy value so that e.g. you can get the count() or first() of the list without evaluating any
         // expensive expressions within the list.
         return new LazyIterableValue({
@@ -29,6 +29,8 @@ export class List extends LookupExpression {
                     this.items.slice(Number(offset), Number(offset + numItems)).map((v) => v.getValue(context)),
                 );
             },
+            sourceExpression: this,
+            sourceExpressionEntryId: context.entryId,
         });
     }
 

--- a/backend/neolace/core/lookup/expressions/literal-expr.ts
+++ b/backend/neolace/core/lookup/expressions/literal-expr.ts
@@ -10,7 +10,7 @@ import { LookupContext } from "../context.ts";
  * e.g. "hello" is a string literal, but `{1 + 1} is two` is not.
  */
 export class LiteralExpression extends LookupExpression {
-    private readonly value: ConcreteValue & IHasLiteralExpression;
+    public readonly value: ConcreteValue & IHasLiteralExpression;
 
     constructor(value: ConcreteValue) {
         super();

--- a/backend/neolace/core/lookup/values/EntryValue.ts
+++ b/backend/neolace/core/lookup/values/EntryValue.ts
@@ -30,9 +30,10 @@ export class EntryValue extends ConcreteValue implements IHasLiteralExpression {
             return new LazyEntrySetValue(
                 context,
                 C`
-                MATCH (entry:${Entry} {id: ${this.id}})-[:${Entry.rel.IS_OF_TYPE}]->(et:${EntryType})-[:${EntryType.rel.FOR_SITE}]->(:${Site} {id: ${context.siteId}})
-                WITH entry, {} AS annotations
-            `,
+                    MATCH (entry:${Entry} {id: ${this.id}})-[:${Entry.rel.IS_OF_TYPE}]->(et:${EntryType})-[:${EntryType.rel.FOR_SITE}]->(:${Site} {id: ${context.siteId}})
+                    WITH entry, {} AS annotations
+                `,
+                { sourceExpression: undefined, sourceExpressionEntryId: undefined },
             );
         }
         return undefined;

--- a/backend/neolace/core/lookup/values/LazyCypherIterableValue.ts
+++ b/backend/neolace/core/lookup/values/LazyCypherIterableValue.ts
@@ -19,4 +19,14 @@ export class LazyCypherIterableValue<ValueType extends LookupValue> extends Abst
     ) {
         super(context, cypherQuery, options.sourceExpression, options.sourceExpressionEntryId);
     }
+
+    public cloneWithSourceExpression(
+        sourceExpression: LookupExpression,
+        sourceExpressionEntryId: VNID,
+    ): LazyCypherIterableValue<ValueType> {
+        return new LazyCypherIterableValue(this.context, this.cypherQuery, this.getSlice, {
+            sourceExpression,
+            sourceExpressionEntryId,
+        });
+    }
 }

--- a/backend/neolace/core/lookup/values/LazyEntrySetValue.ts
+++ b/backend/neolace/core/lookup/values/LazyEntrySetValue.ts
@@ -24,9 +24,9 @@ export class LazyEntrySetValue extends AbstractLazyCypherQueryValue {
         cypherQuery: CypherQuery,
         options: {
             annotations?: Record<string, AnnotationReviver>;
-            sourceExpression?: LookupExpression;
-            sourceExpressionEntryId?: VNID;
-        } = {},
+            sourceExpression?: LookupExpression | undefined;
+            sourceExpressionEntryId?: VNID | undefined;
+        },
     ) {
         super(context, cypherQuery, options.sourceExpression, options.sourceExpressionEntryId);
         this.annotations = options.annotations;
@@ -50,6 +50,17 @@ export class LazyEntrySetValue extends AbstractLazyCypherQueryValue {
             } else {
                 return new EntryValue(r["entry.id"]);
             }
+        });
+    }
+
+    public cloneWithSourceExpression(
+        sourceExpression: LookupExpression | undefined,
+        sourceExpressionEntryId: VNID | undefined,
+    ): LazyEntrySetValue {
+        return new LazyEntrySetValue(this.context, this.cypherQuery, {
+            annotations: this.annotations,
+            sourceExpression,
+            sourceExpressionEntryId,
         });
     }
 }

--- a/backend/neolace/core/lookup/values/PageValue.ts
+++ b/backend/neolace/core/lookup/values/PageValue.ts
@@ -1,20 +1,20 @@
 import { VNID } from "neolace/deps/vertex-framework.ts";
 import type * as api from "neolace/deps/neolace-api.ts";
 import type { LookupExpression } from "../expressions/base.ts";
-import { ConcreteValue } from "./base.ts";
+import { ConcreteValue, IHasSourceExpression } from "./base.ts";
 
 /**
  * A subset of values from a larger value set.
  */
-export class PageValue<T extends ConcreteValue> extends ConcreteValue {
+export class PageValue<T extends ConcreteValue> extends ConcreteValue implements IHasSourceExpression {
     readonly values: ReadonlyArray<T>;
     readonly startedAt: bigint; // Also called "skip"
     readonly pageSize: bigint; // Also called "limit"
     readonly totalCount: bigint;
     /** The source expression can be used along with slice() to retrieve additional pages of the result. */
-    readonly sourceExpression?: LookupExpression;
+    readonly sourceExpression: LookupExpression | undefined;
     /** The entry used for any "this" expressions in the sourceExpression. This could be removed if we could erase "this" expressions. */
-    readonly sourceExpressionEntryId?: VNID;
+    readonly sourceExpressionEntryId: VNID | undefined;
 
     constructor(
         values: ReadonlyArray<T>,
@@ -22,8 +22,8 @@ export class PageValue<T extends ConcreteValue> extends ConcreteValue {
             startedAt: bigint;
             pageSize: bigint;
             totalCount: bigint;
-            sourceExpression?: LookupExpression;
-            sourceExpressionEntryId?: VNID;
+            sourceExpression: LookupExpression | undefined;
+            sourceExpressionEntryId: VNID | undefined;
         },
     ) {
         super();
@@ -56,9 +56,16 @@ export class PageValue<T extends ConcreteValue> extends ConcreteValue {
         return v;
     }
 
-    /** Helper method to quickly make a "Page" value from a fixed array of values */
-    static from<T extends ConcreteValue>(values: T[], minPageSize = 1n): PageValue<T> {
-        const pageSize = values.length < minPageSize ? minPageSize : BigInt(values.length);
-        return new PageValue(values, { startedAt: 0n, pageSize, totalCount: BigInt(values.length) });
+    public cloneWithSourceExpression(
+        sourceExpression: LookupExpression | undefined,
+        sourceExpressionEntryId: VNID | undefined,
+    ): this {
+        return new PageValue(this.values, {
+            pageSize: this.pageSize,
+            startedAt: this.startedAt,
+            totalCount: this.totalCount,
+            sourceExpression,
+            sourceExpressionEntryId,
+        }) as typeof this;
     }
 }


### PR DESCRIPTION
On a page like this:

![Screen Shot 2022-07-23 at 9 58 57 AM](https://user-images.githubusercontent.com/945577/180615149-102e358a-7acb-4345-867c-de770fb653ab.png)

When you click "55 more...", currently you'll see this:

![Screen Shot 2022-07-23 at 9 59 30 AM](https://user-images.githubusercontent.com/945577/180615174-df18f2fc-d440-4927-a8a1-4238a1443fe7.png)

But `this.reverse(prop=Authors)` is confusing (though accurate).

With the change in this PR, now users will see:

![Screen Shot 2022-07-23 at 10 00 11 AM](https://user-images.githubusercontent.com/945577/180615197-f22beeb3-6bcb-455d-b6a3-afa6b9e44df0.png)

This also gets us one step closer to using the general "Lookup" page, and not the entry-specific one.