### PR TITLE
Implement "reslice" so the frontend can properly paginate sliced results

### DIFF
--- a/backend/neolace/core/lookup/parse.test.ts
+++ b/backend/neolace/core/lookup/parse.test.ts
@@ -43,6 +43,18 @@ group("parse.ts", () => {
         assertNotEquals(new Ancestors(new This()), new AndAncestors(new This())); // Ancestors != AndAncestors
     });
 
+    test("Basic expressions", () => {
+        checkParse("this", new This());
+        checkParse("null", new LiteralExpression(new V.NullValue()));
+        checkParse("true", new LiteralExpression(new V.BooleanValue(true)));
+        checkParse("false", new LiteralExpression(new V.BooleanValue(false)));
+    });
+
+    test("Strings", () => {
+        checkParse(`"hello"`, new LiteralExpression(new V.StringValue("hello")));
+        checkParse(`"hello \\"escaped quotes\\""`, new LiteralExpression(new V.StringValue('hello "escaped quotes"')));
+    });
+
     test("Invalid", () => {
         assertThrows(() => parseLookupString("foobar"), LookupParseError);
         assertThrows(() => parseLookupString(".ancestors()"), LookupParseError);

--- a/backend/neolace/core/lookup/parse.ts
+++ b/backend/neolace/core/lookup/parse.ts
@@ -25,6 +25,8 @@ export function parseLookupString(lookup: string, withExtraFunctions: LookupFunc
     lookup = lookup.trim();
 
     if (lookup === "null") return new LiteralExpression(new V.NullValue());
+    if (lookup === "true") return new LiteralExpression(new V.BooleanValue(true));
+    if (lookup === "false") return new LiteralExpression(new V.BooleanValue(false));
     if (lookup === "this") return new This();
 
     const recursiveParse = (otherLookup: string) => parseLookupString(otherLookup, withExtraFunctions);

--- a/frontend/components/LookupEvaluator.tsx
+++ b/frontend/components/LookupEvaluator.tsx
@@ -77,7 +77,7 @@ export const LookupEvaluatorWithPagination: React.FunctionComponent<Props> = (pr
         const numPagesTotal = Math.ceil(pageData.totalCount / numValuesPerPage);
         const pages = [];
         for (let i = 0; i < numPagesDisplayed; i++) {
-            const expr = i === 0 ? props.expr : `slice(${props.expr}, start=${i * numValuesPerPage}, size=${numValuesPerPage})`;
+            const expr = i === 0 ? props.expr : `slice(${props.expr}, start=${i * numValuesPerPage}, size=${numValuesPerPage}, reslice=true)`;
             pages.push(<LookupEvaluator key={expr} expr={expr} mdtContext={props.mdtContext} hideShowMoreLink={true} pageSize={props.pageSize} />);
         }
         return <>


### PR DESCRIPTION
Consider [this lookup expression](http://docs.local.neolace.net:5555/lookup?e=[1%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C9%2C10%2C11%2C12%2C13%2C14%2C15%2C16%2C17%2C18%2C19%2C20].slice(size%3D3)):
![Screen Shot 2022-07-23 at 12 01 25 PM](https://user-images.githubusercontent.com/945577/180619312-99b77de6-7aca-499b-b3ce-6bde1dd85594.png)

Clicking "Show more results" currently gives this error: **Error (LookupEvaluationError): The expression "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 1…e=3)" is not iterable.**

With this PR, the frontend uses a new `reslice=true` parameter when requesting additional pages, which allows the pagination to work correctly, and the "Show More Results" button now works well.