### PR TITLE
feat: Exclude specific entries from a set

### DIFF
--- a/backend/neolace/core/lookup/expressions/functions/filter.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/filter.test.ts
@@ -89,4 +89,34 @@ group("filter.ts", () => {
             }),
         ]);
     });
+
+    test(`x.filter(exclude=[multiple entries]) excludes specific entries`, async () => {
+        const entries = new AndAncestors(new This());
+        // Filter "ponderosa pine and its ancestors" to only entries of type "Genus" or "Order":
+        const value = await context.evaluateExprConcrete(
+            new Filter(entries, {
+                exclude: new List([
+                    new This(),
+                    new LiteralExpression(new V.EntryValue(defaultData.entries.genusPinus.id)),
+                ]),
+            }),
+        );
+        assertInstanceOf(value, V.PageValue);
+        assertEquals(value.values, [
+            // "This" (ponderosa pine) is excluded
+            // Genus (distance 1) is excluded
+            new V.AnnotatedValue(new V.EntryValue(defaultData.entries.familyPinaceae.id), {
+                distance: new V.IntegerValue(2),
+            }),
+            new V.AnnotatedValue(new V.EntryValue(defaultData.entries.orderPinales.id), {
+                distance: new V.IntegerValue(3),
+            }),
+            new V.AnnotatedValue(new V.EntryValue(defaultData.entries.classPinopsida.id), {
+                distance: new V.IntegerValue(4),
+            }),
+            new V.AnnotatedValue(new V.EntryValue(defaultData.entries.divisionTracheophyta.id), {
+                distance: new V.IntegerValue(5),
+            }),
+        ]);
+    });
 });


### PR DESCRIPTION
This allows creating a set of related entries and then on each of those entries displaying "Related entries: (every entry in the set _excluding_ this)"

![Screen Shot 2022-08-08 at 10 52 29 PM](https://user-images.githubusercontent.com/945577/183574683-9205cbfd-f7be-4da0-8eb2-89a8230381ab.png)

![Screen Shot 2022-08-08 at 10 52 43 PM](https://user-images.githubusercontent.com/945577/183574703-354b92d7-cc40-424d-b6f0-1cdcc05ec882.png)

Related functions is: `this.get(prop=prop("_PROP_RELATED_FUNCTION_SET")).reverse(prop=prop("_PROP_RELATED_FUNCTION_SET")).filter(exclude=[this])`
