### PR TITLE
fix: on mobile, inline code blocks weren't getting line breaks as needed

### DIFF
--- a/frontend/global-styles.css
+++ b/frontend/global-styles.css
@@ -88,7 +88,7 @@
     }
     /* Code */
     .neo-typography code {
-        @apply text-sky-900;
+        @apply text-sky-900 break-words;
     }
     /* Code Block */
     .neo-typography code pre {


### PR DESCRIPTION
Fixes this issue with formatting [this blog post](https://junction.neolace.com/entry/parsing-lookup-expressions-using-chevrotain) on mobile:

![IMG_4528](https://user-images.githubusercontent.com/945577/184237854-8c58617a-ec2e-4587-bbf9-9e771e49fb15.PNG)
