### PR TITLE
Use React context to set z-index more accurately throughout the UI

### DIFF
--- a/frontend/components/form-input/AutocompletionMenu.tsx
+++ b/frontend/components/form-input/AutocompletionMenu.tsx
@@ -3,6 +3,7 @@ import { Portal } from 'components/utils/Portal';
 import { api, useDraft, useLookupExpression } from 'lib/api';
 import { InlineMDT, MDTContext } from 'components/markdown-mdt/mdt';
 import { EntitySymbol } from "../widgets/EntitySymbol";
+import { IncreaseZIndex, useZIndex } from "lib/hooks/useZIndex";
 
 
 type EntityValue = api.EntryValue | api.PropertyValue | api.EntryTypeValue;
@@ -78,6 +79,7 @@ export const AutocompletionMenu: React.FunctionComponent<Props> = ({ searchTerm,
     }, [result?.referenceCache, searchTerm, draft, unsavedEdits]);
 
     const mdtContext = React.useMemo(() => new MDTContext({ refCache, disableInteractiveFeatures: true }), [refCache]);
+    const zIndex = useZIndex({increaseBy: IncreaseZIndex.ForDropdown});
 
     if (error) {
         console.error(error);
@@ -92,7 +94,7 @@ export const AutocompletionMenu: React.FunctionComponent<Props> = ({ searchTerm,
         <Portal>
             <div
                 className="absolute border rounded bg-white border-slate-700 shadow-md"
-                style={{ left: props.positionLeft, top: props.positionTop }}
+                style={{ left: props.positionLeft, top: props.positionTop, zIndex }}
             >
                 <ul>
                     {items.slice(0, 8).map((item) => (

--- a/frontend/components/form-input/SelectBox.tsx
+++ b/frontend/components/form-input/SelectBox.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { displayText, TranslatableText } from "components/utils/i18n";
 import { Icon, IconId } from "../widgets/Icon";
 import { useClickOutsideHandler } from "lib/hooks/useClickOutsideHandler";
+import { IncreaseZIndex, useZIndex } from "lib/hooks/useZIndex";
 
 export interface SelectOption {
     id: string;
@@ -91,6 +92,7 @@ export const SelectBox: React.FunctionComponent<Props> = ({ onChange, options, v
     const { classNameButton, node: buttonContent } = selectedOption
         ? renderOption(selectedOption)
         : { classNameButton: "", node: "" };
+    const zIndex = useZIndex({increaseBy: IncreaseZIndex.ForDropdown});
 
     return (
         <div className={`relative max-w-full ${props.className ?? "w-[600px]"}`} ref={outerDiv}>
@@ -120,8 +122,8 @@ export const SelectBox: React.FunctionComponent<Props> = ({ onChange, options, v
                     unstyled absolute -mt-[5px] mx-[3px] w-full ${isMenuVisible ? "block" : "hidden"}
                     max-h-64 overflow-auto
                     rounded-md bg-white border border-gray-500 shadow-lg
-                    z-widget
                 `}
+                style={{zIndex}}
                 role="listbox"
                 aria-activedescendant={selectedItem}
                 tabIndex={-1}

--- a/frontend/components/utils/Portal.tsx
+++ b/frontend/components/utils/Portal.tsx
@@ -17,7 +17,7 @@ interface Props {
  */
 export const Portal: React.FC<Props> = ({
     children,
-    className = "root-portal top-0 left-0 w-full z-modal",
+    className = "root-portal top-0 left-0 w-full",
     el = "div",
 }) => {
     const [container, setContainer] = React.useState<HTMLElement | null>(null);

--- a/frontend/components/widgets/Modal.tsx
+++ b/frontend/components/widgets/Modal.tsx
@@ -1,7 +1,8 @@
+import React from "react";
 import { useClickOutsideHandler } from "lib/hooks/useClickOutsideHandler";
 import { useKeyHandler } from "lib/hooks/useKeyHandler";
 import { Portal } from "components/utils/Portal";
-import React from "react";
+import { useZIndex, IncreaseZIndex, ZIndexContext } from "lib/hooks/useZIndex";
 
 interface ModalProps {
     children?: React.ReactNode;
@@ -26,9 +27,11 @@ export const Modal: React.FunctionComponent<ModalProps> = ({ onClose, ...props }
     useClickOutsideHandler(modalElement, handleClickOutside);
     useKeyHandler("Escape", handleClickOutside);
 
+    const zIndex = useZIndex({increaseBy: IncreaseZIndex.ForModal});
+
     return (
-        <>
-            <Portal>
+        <Portal>
+            <ZIndexContext.Provider value={zIndex}>
                 <div
                     ref={modalElement}
                     role="dialog"
@@ -37,13 +40,14 @@ export const Modal: React.FunctionComponent<ModalProps> = ({ onClose, ...props }
                         // Modals are centered in the viewport, and not affected by scrolling (fixed):
                         `fixed left-[50vw] top-[50vh] -translate-x-1/2 -translate-y-1/2 ` +
                         // And this is the default appearance of our modals:
-                        `border p-0 rounded bg-white border-gray-800 shadow font-normal z-modal ` +
+                        `border p-0 rounded bg-white border-gray-800 shadow font-normal` +
                         (props.className ?? "")
                     }
+                    style={{zIndex}}
                 >
                     {props.children}
                 </div>
-            </Portal>
-        </>
+            </ZIndexContext.Provider>
+        </Portal>
     );
 };

--- a/frontend/components/widgets/Tooltip.tsx
+++ b/frontend/components/widgets/Tooltip.tsx
@@ -1,7 +1,9 @@
-import type { VirtualElement } from "@popperjs/core";
-import { Portal } from "components/utils/Portal";
 import React from "react";
 import { usePopper } from "react-popper";
+import type { VirtualElement } from "@popperjs/core";
+
+import { Portal } from "components/utils/Portal";
+import { useZIndex, IncreaseZIndex, ZIndexContext } from "lib/hooks/useZIndex";
 
 interface TooltipProps {
     tooltipContent: React.ReactNode;
@@ -59,6 +61,8 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = (props) => {
         };
     }, [popperElement, showTooltip, props.onClickOutsideTooltip, handleClickOutside]);
 
+    const zIndex = useZIndex({increaseBy: IncreaseZIndex.ForTooltip});
+
     return (
         <>
             {typeof props.children === "function" ? props.children({
@@ -75,17 +79,19 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = (props) => {
                     role="tooltip"
                     id={tooltipId}
                     ref={setPopperElement}
-                    style={styles.popper}
+                    style={{...styles.popper, zIndex}}
                     {...attributes.popper}
                     className={`
-                        max-w-[400px] border p-1 rounded border-gray-800 shadow bg-blue-50 z-tooltip
+                        max-w-[400px] border p-1 rounded border-gray-800 shadow bg-blue-50
                         text-sm font-normal neo-typography
                         ${showTooltip ? "visible opacity-100" : "invisible opacity-0"}
                         transition-opacity duration-500
                     `}
                     aria-hidden={!showTooltip}
                 >
-                    {showTooltip ? props.tooltipContent : null}
+                    <ZIndexContext.Provider value={zIndex}>
+                        {showTooltip ? props.tooltipContent : null}
+                    </ZIndexContext.Provider>
                 </div>
             </Portal>
         </>

--- a/frontend/global-styles.css
+++ b/frontend/global-styles.css
@@ -28,12 +28,6 @@
         */
     }
 
-    /* Z-indexes */
-    .z-widget { @apply z-[1]; } /* Widgets like the dropdown of a select box */
-    .z-modal { @apply z-20; } /* Modal dialogs */
-    .z-tooltip { @apply z-30; } /* Tooltips */
-    .z-mobile-menu { @apply z-50; } /* The menu that can be triggered on mobile, which slides in from the left and must be in front of everything on the page */
-
     /* Typography: apply this class to a section that contains prose, to ensure headings have reasonable size/weight, paragraphs are spaced, etc. */
     .neo-typography h1,
     .neo-typography h2,

--- a/frontend/lib/hooks/useZIndex.ts
+++ b/frontend/lib/hooks/useZIndex.ts
@@ -1,0 +1,24 @@
+import React from "react";
+
+/**
+ * Use this to get/set the current zIndex of the React tree. Used to ensure that widget tooltips in modals have higher
+ * z-index that tooltips outside the modal, for example.
+ */
+ export const ZIndexContext = React.createContext<number>(0); // default zIndex is 0
+
+export enum IncreaseZIndex {
+    NoChange = 0,
+    ForTooltip = 5,
+    ForDropdown = 1,
+    ForModal = 10,
+    ForMobileMenu = 50,
+}
+
+/**
+ * Get the "current" z-index at this point in the React tree. Used to correctly ensure that dropdowns, tooltips, and
+ * modals have the correct z-index.
+ */
+export function useZIndex(options: {increaseBy?: IncreaseZIndex} = {}): number {
+    const zIndex = React.useContext(ZIndexContext);
+    return zIndex + (options.increaseBy ?? 0);
+}


### PR DESCRIPTION
In the "Entry Type" editor, the autocompletion dropdown was appearing behind the modal:

![Screen Shot 2022-09-15 at 10 48 36 AM](https://user-images.githubusercontent.com/945577/190494886-761222f4-e17a-42ce-8bbd-ac7c6f424730.png)

I fixed this by using a React context to make each component aware of the z-index of its parent component in the React tree.