### PR TITLE
refactor(frontend): Move "Reference Cache" data to a React Context

### DIFF
--- a/frontend/components/EntryPage.tsx
+++ b/frontend/components/EntryPage.tsx
@@ -3,7 +3,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import Link from "next/link";
 import Image from "next/future/image";
 import { Blurhash } from "react-blurhash";
-import { api, useEntry } from "lib/api";
+import { api, RefCacheContext, useEntry } from "lib/api";
 
 import { SitePage } from "components/SitePage";
 import { InlineMDT, MDTContext, RenderMDT } from "components/markdown-mdt/mdt";
@@ -41,14 +41,7 @@ export const EntryPage: React.FunctionComponent<Props> = function (props) {
     const [entry, entryError] = useEntry(props.entrykey, props.publicEntry);
     const intl = useIntl();
 
-    // When the entry page loads, it uses SWR to fetch the latest/user-specific version of the entry from the server,
-    // though in most cases it will be the same. To avoid re-rendering the whole React tree, we need to use
-    // JSON.stringify to compare the reference cache by value.
-    const mdtContext = React.useMemo(() => new MDTContext({
-        entryId: entry?.id,
-        refCache: entry?.referenceCache,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }), [entry?.id, JSON.stringify(entry?.referenceCache ?? "")]);
+    const mdtContext = React.useMemo(() => new MDTContext({ entryId: entry?.id }), [entry?.id]);
 
     if (entryError) {
         if (entryError instanceof api.NotAuthorized) {
@@ -91,193 +84,195 @@ export const EntryPage: React.FunctionComponent<Props> = function (props) {
     const hasProps = entry.propertiesSummary?.length ?? 0 > 0;
 
     return (
-        <SitePage
+        <RefCacheContext.Provider value={{refCache: entry.referenceCache}}>
+            <SitePage
 
-            // The name of this entry is the <title> of the page
-            title={entry.name}
+                // The name of this entry is the <title> of the page
+                title={entry.name}
 
-            // First define what widgets we have in the left-hand column on each entry page.
-            // These are the defaults, but plugins can always change/add/remove them.
-            leftNavTopSlot={[
-                // First display the name of the entry:
-                {id: "entryName", priority: 20, content: <>
-                    <strong className="block mt-2">{entry.name}</strong>
-                </>},
-                // Then we used to display the friendlyId. For now it's hidden but it's kept in the HTML because
-                // it's useful to have somewhere in the HTML to find the VNID and friendlyId.
-                {id: "entryId", priority: 21, content: <>
-                    <code id="entry-id" data-entry-id={entry.id} className="font-mono font-light hidden">{entry.friendlyId}</code>
-                </>},
-                // These are the links to each heading in the entry's article, if any, as well as to the summary and properties at the top:
-                {id: "tableOfContents", priority: 50, content: <>
-                    <ul id="left-toc-headings">
-                        <li><Link href={`/entry/${entry.friendlyId}#summary`}><FormattedMessage id="RrCui3" defaultMessage="Summary"/></Link></li>
-                        <li className={`${hasProps || "hidden"}`}><Link href={`/entry/${entry.friendlyId}#properties`}><FormattedMessage id="aI80kg" defaultMessage="Properties"/></Link></li>
-                        {
-                            entry.features?.Article?.headings.map(heading =>
-                                <li key={heading.id}><Link href={`/entry/${entry.friendlyId}#h-${heading.id}`}>{heading.title}</Link></li>
-                            )
-                        }
-                    </ul>
-                </>},
-                // Action links, e.g. to edit this entry, view change history, etc.
-                ...(DEVELOPMENT_MODE ? [
-                    {id: "entryActions", priority: 60, content: <>
-                    <ul id="entry-actions" className="mt-4">
-                        <li><Link href={`/draft/_/entry/${entry.id}/edit`}><FormattedMessage id="wEQDC6" defaultMessage="Edit"/></Link></li>
-                    </ul>
-                </>},
-                ] : [])
-            ]}
-        >
-            {/* Hero image, if any */}
-            {
-                entry.features?.HeroImage ?
-                    <div className="-m-6 mb-7 relative h-[30vh] md:h-[50vh]" style={(
-                        /*
-                            If the image is landscape (significantly wider than it is tall), make it as wide as the page and adjust the height to match.
-                            Otherwise (if square-ish or vertical), use a fixed aspect ratio container and either display the image centered or stretch the
-                            image to "cover" the area, depending on the image contents.
-                        */
-                        (entry.features.HeroImage.width && entry.features.HeroImage.height && (entry.features.HeroImage.width > entry.features.HeroImage.height * 1.4))
-                            ? {aspectRatio: `${entry.features.HeroImage.width} / ${entry.features.HeroImage.height}`, height: "auto", minHeight: "20vh" /* for old safari that doesn't support aspect-ratio */}
-                            : {}
-                    )}>
-                        {/* A blurry representation of the hero image, shown while it is loading: */}
-                        <Blurhash
-                            hash={entry.features.HeroImage.blurHash ?? ""}
-                            width="100%"
-                            height="100%"
-                        />
-                        {/*
-                            The hero image. Depending on the content of the image, we crop it using "cover" or shrink it
-                            proportionally to fit, using "contain".
-                            * Photos with the subject in the center with lots of space around it are ideal for "cover";
-                              it's fine to crop out parts of them to make the image fit.
-                            * Images where the subject almost touches all four sides and seeing the whole thing without
-                              cropping is important - those need to use "contain".
-
-                            If the image is significantly wider than it is tall, it doesn't matter - we adjust the
-                            height to fit exactly anyways (see above).
-                        */}
-                        <Image
-                            src={entry.features.HeroImage.imageUrl}
-                            loader={imgThumbnailLoader}
-                            alt=""
-                            fill
-                            className={`${entry.features.HeroImage.sizing === api.ImageSizingMode.Contain ? "object-contain" : "object-cover"}`}
-                            sizes="1000px"
-                            priority
-                        />
-
-                        {/* Display the caption, if any, at the bottom right of the hero image. */}
-                        {entry.features.HeroImage.caption ?
-                            <div className="absolute bottom-0 right-0 bg-opacity-60 bg-gray-50 text-gray-800 text-xs p-2 max-w-lg backdrop-blur-sm rounded-tl font-light">
-                                <EntryLink entryKey={entry.features.HeroImage.entryId} mdtContext={mdtContext}>
-                                    <FormattedMessage id="lr4lXN" defaultMessage="Image:"/>
-                                </EntryLink>&nbsp;
-                                <InlineMDT mdt={entry.features.HeroImage.caption} context={mdtContext} />
-                            </div>
-                        : null}
-                    </div>
-                : null
-            }
-
-            {/* Summary: The entry name and description */}
-            <h1 id="summary">{entry.name}</h1>
-            <p id="description"><InlineMDT mdt={entry.description ?? ""} context={mdtContext} /></p>
-
-            {/* Properties */}
-            <div className={`flex flex-wrap xl:flex-nowrap ${hasProps || "hidden"}`}>
-                <div id="properties" className="flex-auto">
-                    <h2><FormattedMessage id="aI80kg" defaultMessage="Properties"/></h2>
-                    <table className="w-full table-fixed">
-                        <colgroup>
-                            <col className="w-full md:w-1/4" />
-                            <col/>
-                        </colgroup>
-                        <tbody>
-                            {entry.propertiesSummary?.map(p => 
-                                <tr key={p.propertyId} className="even:bg-[#fbfbfe]">
-                                    {/* The property (e.g. "Population") */}
-                                    <th className="block md:table-cell text-xs md:text-base -mb-1 md:mb-0 pt-1 md:py-1 pr-2 align-top text-left font-normal text-gray-500 md:text-gray-700 min-w-[120px]">
-                                        <LookupValue value={{type: "Property", id: p.propertyId}} mdtContext={mdtContext} />
-                                    </th>
-                                    {/* The property value (e.g. "38 million people") */}
-                                    <td className="block md:table-cell pr-2 pb-1 md:py-1 text-sm md:text-base">
-                                        <LookupValue value={p.value} mdtContext={mdtContext} defaultListMode="compact" />
-                                    </td>
-                                </tr>
-                            )}
-                        </tbody>
-                    </table>
-                </div>
-                {/*
-                // In an earlier design, we always displayed a graph here. Currently we don't do that, and a graph will
-                // only be displayed if explicitly added to the entry type as a "property" - see technotes.org for an
-                // example of this.
-                <div id="graph-thumbnail" className="hidden md:block flex-initial">
-                    <h2><FormattedMessage id="site.entry.graphHeading" defaultMessage="Explore Graph"/></h2>
-                    <div className="bg-gray-200 pb-[50%] text-center">(graph)</div>
-                </div>
-                */}
-            </div>
-
-            <div id="entry-contents">
-
-                {/*
-                    Before the content of the entry, here is a slot that allows plugins to display additional content or
-                    UI widgets. By default, there is nothing here and thus is is not visible.
-                    We use 'cloneElement' in order to pass 'entry' as a prop to the plugin widgets; but in the future we
-                    may have a nicer way to do this using EntryContext/<EntryContext.Provider>.
-                */}
-                <UISlot slotId="entryPreFeature" defaultContents={[]} renderWidget={(w) => React.cloneElement(w.content, { key: w.id, entry, })} />
-
-                {/*
-                    If this _is_ an image entry (this entry has the "image" feature), display the image here.
-                    This is different than the "hero image" above, which is not the main content of the entry, but just
-                    an image displayed with the entry to make it look nicer.
-
-                    Typically an entry is either an image entry or an article entry (or neither), but not both. However,
-                    it _could_ have both if there was a use case for that, so we do allow that option.
-                */}
+                // First define what widgets we have in the left-hand column on each entry page.
+                // These are the defaults, but plugins can always change/add/remove them.
+                leftNavTopSlot={[
+                    // First display the name of the entry:
+                    {id: "entryName", priority: 20, content: <>
+                        <strong className="block mt-2">{entry.name}</strong>
+                    </>},
+                    // Then we used to display the friendlyId. For now it's hidden but it's kept in the HTML because
+                    // it's useful to have somewhere in the HTML to find the VNID and friendlyId.
+                    {id: "entryId", priority: 21, content: <>
+                        <code id="entry-id" data-entry-id={entry.id} className="font-mono font-light hidden">{entry.friendlyId}</code>
+                    </>},
+                    // These are the links to each heading in the entry's article, if any, as well as to the summary and properties at the top:
+                    {id: "tableOfContents", priority: 50, content: <>
+                        <ul id="left-toc-headings">
+                            <li><Link href={`/entry/${entry.friendlyId}#summary`}><FormattedMessage id="RrCui3" defaultMessage="Summary"/></Link></li>
+                            <li className={`${hasProps || "hidden"}`}><Link href={`/entry/${entry.friendlyId}#properties`}><FormattedMessage id="aI80kg" defaultMessage="Properties"/></Link></li>
+                            {
+                                entry.features?.Article?.headings.map(heading =>
+                                    <li key={heading.id}><Link href={`/entry/${entry.friendlyId}#h-${heading.id}`}>{heading.title}</Link></li>
+                                )
+                            }
+                        </ul>
+                    </>},
+                    // Action links, e.g. to edit this entry, view change history, etc.
+                    ...(DEVELOPMENT_MODE ? [
+                        {id: "entryActions", priority: 60, content: <>
+                        <ul id="entry-actions" className="mt-4">
+                            <li><Link href={`/draft/_/entry/${entry.id}/edit`}><FormattedMessage id="wEQDC6" defaultMessage="Edit"/></Link></li>
+                        </ul>
+                    </>},
+                    ] : [])
+                ]}
+            >
+                {/* Hero image, if any */}
                 {
-                    entry.features?.Image ?
-                        <>
-                            <h2><FormattedMessage id="+0zv6g" defaultMessage="Image"/></h2>
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img
-                                src={entry.features.Image.imageUrl}
-                                alt={intl.formatMessage({defaultMessage: 'The image attached to this entry.', id: 'RuO3eW'})}
+                    entry.features?.HeroImage ?
+                        <div className="-m-6 mb-7 relative h-[30vh] md:h-[50vh]" style={(
+                            /*
+                                If the image is landscape (significantly wider than it is tall), make it as wide as the page and adjust the height to match.
+                                Otherwise (if square-ish or vertical), use a fixed aspect ratio container and either display the image centered or stretch the
+                                image to "cover" the area, depending on the image contents.
+                            */
+                            (entry.features.HeroImage.width && entry.features.HeroImage.height && (entry.features.HeroImage.width > entry.features.HeroImage.height * 1.4))
+                                ? {aspectRatio: `${entry.features.HeroImage.width} / ${entry.features.HeroImage.height}`, height: "auto", minHeight: "20vh" /* for old safari that doesn't support aspect-ratio */}
+                                : {}
+                        )}>
+                            {/* A blurry representation of the hero image, shown while it is loading: */}
+                            <Blurhash
+                                hash={entry.features.HeroImage.blurHash ?? ""}
+                                width="100%"
+                                height="100%"
                             />
-                        </>
+                            {/*
+                                The hero image. Depending on the content of the image, we crop it using "cover" or shrink it
+                                proportionally to fit, using "contain".
+                                * Photos with the subject in the center with lots of space around it are ideal for "cover";
+                                it's fine to crop out parts of them to make the image fit.
+                                * Images where the subject almost touches all four sides and seeing the whole thing without
+                                cropping is important - those need to use "contain".
+
+                                If the image is significantly wider than it is tall, it doesn't matter - we adjust the
+                                height to fit exactly anyways (see above).
+                            */}
+                            <Image
+                                src={entry.features.HeroImage.imageUrl}
+                                loader={imgThumbnailLoader}
+                                alt=""
+                                fill
+                                className={`${entry.features.HeroImage.sizing === api.ImageSizingMode.Contain ? "object-contain" : "object-cover"}`}
+                                sizes="1000px"
+                                priority
+                            />
+
+                            {/* Display the caption, if any, at the bottom right of the hero image. */}
+                            {entry.features.HeroImage.caption ?
+                                <div className="absolute bottom-0 right-0 bg-opacity-60 bg-gray-50 text-gray-800 text-xs p-2 max-w-lg backdrop-blur-sm rounded-tl font-light">
+                                    <EntryLink entryKey={entry.features.HeroImage.entryId} mdtContext={mdtContext}>
+                                        <FormattedMessage id="lr4lXN" defaultMessage="Image:"/>
+                                    </EntryLink>&nbsp;
+                                    <InlineMDT mdt={entry.features.HeroImage.caption} context={mdtContext} />
+                                </div>
+                            : null}
+                        </div>
                     : null
                 }
 
-                {/* Article content, if any */}
-                {
-                    entry.features?.Article ?
-                        <RenderMDT 
-                            // The Markdown (MDT) of this article
-                            mdt={entry.features.Article.articleMD}
-                            // The page already has an <h1> (the entry title, above), so we "shift" all headings in
-                            // the markdown so that the first heading in the markdown will be rendered here as an <h2>.
-                            // This is because each HTML page should only have one <h1> heading.
-                            context={mdtContext.childContextWith({headingShift: 1})}
-                        />
-                    : null
-                }
-            </div>
+                {/* Summary: The entry name and description */}
+                <h1 id="summary">{entry.name}</h1>
+                <p id="description"><InlineMDT mdt={entry.description ?? ""} context={mdtContext} /></p>
 
-            <div id="entry-end">
-                {/*
-                    After the content of the entry, here is a slot that allows plugins to display additional content or
-                    UI widgets. By default, there is nothing here and thus is is not visible.
-                    We use 'cloneElement' in order to pass 'entry' as a prop to the plugin widgets; but in the future we
-                    may have a nicer way to do this using EntryContext/<EntryContext.Provider>.
-                */}
-                <UISlot slotId="entryAfterContent" defaultContents={[]} renderWidget={(w) => React.cloneElement(w.content, { key: w.id, entry, })} />
-            </div>
-        </SitePage>
+                {/* Properties */}
+                <div className={`flex flex-wrap xl:flex-nowrap ${hasProps || "hidden"}`}>
+                    <div id="properties" className="flex-auto">
+                        <h2><FormattedMessage id="aI80kg" defaultMessage="Properties"/></h2>
+                        <table className="w-full table-fixed">
+                            <colgroup>
+                                <col className="w-full md:w-1/4" />
+                                <col/>
+                            </colgroup>
+                            <tbody>
+                                {entry.propertiesSummary?.map(p => 
+                                    <tr key={p.propertyId} className="even:bg-[#fbfbfe]">
+                                        {/* The property (e.g. "Population") */}
+                                        <th className="block md:table-cell text-xs md:text-base -mb-1 md:mb-0 pt-1 md:py-1 pr-2 align-top text-left font-normal text-gray-500 md:text-gray-700 min-w-[120px]">
+                                            <LookupValue value={{type: "Property", id: p.propertyId}} mdtContext={mdtContext} />
+                                        </th>
+                                        {/* The property value (e.g. "38 million people") */}
+                                        <td className="block md:table-cell pr-2 pb-1 md:py-1 text-sm md:text-base">
+                                            <LookupValue value={p.value} mdtContext={mdtContext} defaultListMode="compact" />
+                                        </td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                    {/*
+                    // In an earlier design, we always displayed a graph here. Currently we don't do that, and a graph will
+                    // only be displayed if explicitly added to the entry type as a "property" - see technotes.org for an
+                    // example of this.
+                    <div id="graph-thumbnail" className="hidden md:block flex-initial">
+                        <h2><FormattedMessage id="site.entry.graphHeading" defaultMessage="Explore Graph"/></h2>
+                        <div className="bg-gray-200 pb-[50%] text-center">(graph)</div>
+                    </div>
+                    */}
+                </div>
+
+                <div id="entry-contents">
+
+                    {/*
+                        Before the content of the entry, here is a slot that allows plugins to display additional content or
+                        UI widgets. By default, there is nothing here and thus is is not visible.
+                        We use 'cloneElement' in order to pass 'entry' as a prop to the plugin widgets; but in the future we
+                        may have a nicer way to do this using EntryContext/<EntryContext.Provider>.
+                    */}
+                    <UISlot slotId="entryPreFeature" defaultContents={[]} renderWidget={(w) => React.cloneElement(w.content, { key: w.id, entry, })} />
+
+                    {/*
+                        If this _is_ an image entry (this entry has the "image" feature), display the image here.
+                        This is different than the "hero image" above, which is not the main content of the entry, but just
+                        an image displayed with the entry to make it look nicer.
+
+                        Typically an entry is either an image entry or an article entry (or neither), but not both. However,
+                        it _could_ have both if there was a use case for that, so we do allow that option.
+                    */}
+                    {
+                        entry.features?.Image ?
+                            <>
+                                <h2><FormattedMessage id="+0zv6g" defaultMessage="Image"/></h2>
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                    src={entry.features.Image.imageUrl}
+                                    alt={intl.formatMessage({defaultMessage: 'The image attached to this entry.', id: 'RuO3eW'})}
+                                />
+                            </>
+                        : null
+                    }
+
+                    {/* Article content, if any */}
+                    {
+                        entry.features?.Article ?
+                            <RenderMDT 
+                                // The Markdown (MDT) of this article
+                                mdt={entry.features.Article.articleMD}
+                                // The page already has an <h1> (the entry title, above), so we "shift" all headings in
+                                // the markdown so that the first heading in the markdown will be rendered here as an <h2>.
+                                // This is because each HTML page should only have one <h1> heading.
+                                context={mdtContext.childContextWith({headingShift: 1})}
+                            />
+                        : null
+                    }
+                </div>
+
+                <div id="entry-end">
+                    {/*
+                        After the content of the entry, here is a slot that allows plugins to display additional content or
+                        UI widgets. By default, there is nothing here and thus is is not visible.
+                        We use 'cloneElement' in order to pass 'entry' as a prop to the plugin widgets; but in the future we
+                        may have a nicer way to do this using EntryContext/<EntryContext.Provider>.
+                    */}
+                    <UISlot slotId="entryAfterContent" defaultContents={[]} renderWidget={(w) => React.cloneElement(w.content, { key: w.id, entry, })} />
+                </div>
+            </SitePage>
+        </RefCacheContext.Provider>
     );
 }

--- a/frontend/components/graph/Graph.tsx
+++ b/frontend/components/graph/Graph.tsx
@@ -2,7 +2,7 @@
  * A graph that is displayed as the result of the .graph() lookup function.
  */
 import React from "react";
-import { api } from "lib/api";
+import { api, useRefCache } from "lib/api";
 import { MDTContext } from "../markdown-mdt/mdt";
 import G6, { Graph, GraphOptions, IG6GraphEvent, INode, NodeConfig } from "@antv/g6";
 import { useResizeObserver } from "lib/hooks/useResizeObserver";
@@ -117,19 +117,20 @@ export const LookupGraph: React.FunctionComponent<GraphProps> = (props) => {
     const [activeTool, setActiveTool, activeToolRef] = useStateRef(Tool.Select);
     /** Is the graph currently expanded (displayed in a large modal?) */
     const [expanded, setExpanded, expandedRef] = useStateRef(false);
+    const refCache = useRefCache();
 
     // The data (nodes and relationships) that we want to display as a graph.
     const originalData = React.useMemo(() => {
-        return convertValueToData(props.value, props.mdtContext.refCache);
-    }, [props.value, props.mdtContext.refCache]);
+        return convertValueToData(props.value, refCache);
+    }, [props.value, refCache]);
     const [transformList, setTransforms] = React.useState<Transform[]>(emptyTransforms);
 
     const currentData = React.useMemo(() => {
         debugLog(`Computing currentData from originalData + ${transformList.length} transform(s).`);
         let transformedData = applyTransforms(originalData, transformList);
-        transformedData = colorGraph(transformedData, transformList, props.mdtContext.refCache);
+        transformedData = colorGraph(transformedData, transformList, refCache);
         return transformedData;
-    }, [originalData, transformList, props.mdtContext.refCache]);
+    }, [originalData, transformList, refCache]);
 
     // In order to preserve our G6 graph when we move it to a modal (when expanding the view), the <div> that contains
     // it must not be destroyed and re-created. React will normally try to destroy and re-create it, not realizing that

--- a/frontend/components/slate-editor/slate-mdt.tsx
+++ b/frontend/components/slate-editor/slate-mdt.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Icon } from "components/widgets/Icon";
 import { LookupExpressionInput } from "components/form-input";
-import { api, useDraft, useLookupExpression, useSchema } from "lib/api";
+import { api, useEntrySummary, useSchema } from "lib/api";
 import { type MDT } from "neolace-api";
 import { Transforms } from "slate";
 import { ReactEditor, RenderElementProps, useFocused, useSelected, useSlate } from "slate-react";
@@ -85,14 +85,7 @@ export const EntryVoid = (
     },
 ) => {
     const [selected, exclusivelySelected] = useVoidSelectionStatus();
-    // TBD: we need a hook to get the current draft OR current entry + refCache
-    const lookupData = useLookupExpression(`entry("${entryId}")`);
-    const [draft, unsavedEdits] = useDraft();
-    let referenceCache = lookupData.result?.referenceCache;
-    if (referenceCache && draft) {
-        referenceCache = api.applyEditsToReferenceCache(referenceCache, [...draft.edits, ...unsavedEdits]);
-    }
-    const entryData = referenceCache?.entries[entryId];
+    const [entryData, referenceCache, _error] = useEntrySummary(entryId);
     const entryName = entryData?.name ?? `Entry ${entryId}`;
     const entryTypeData = referenceCache?.entryTypes[entryData?.entryType.id ?? ""];
     const colors = api.entryTypeColors[entryTypeData?.color ?? api.EntryTypeColor.Default];

--- a/frontend/components/widgets/EntitySymbol.tsx
+++ b/frontend/components/widgets/EntitySymbol.tsx
@@ -1,5 +1,4 @@
-import { MDTContext } from "components/markdown-mdt/mdt";
-import { api } from "lib/api";
+import { api, useRefCache } from "lib/api";
 import { Icon } from "./Icon";
 
 type EntityValue = api.EntryValue | api.PropertyValue | api.EntryTypeValue;
@@ -9,13 +8,13 @@ type EntityValue = api.EntryValue | api.PropertyValue | api.EntryTypeValue;
  */
 export const EntitySymbol: React.FunctionComponent<{
     value: EntityValue,
-    mdtContext: MDTContext,
     selected?: boolean,
     className?: string,
     roundedLeftOnly?: boolean,
     defaultBg?: string,
-}> = ({ value, mdtContext, selected = false, className = "", roundedLeftOnly = false, defaultBg = "bg-gray-200" }) => {
+}> = ({ value, selected = false, className = "", roundedLeftOnly = false, defaultBg = "bg-gray-200" }) => {
 
+    const refCache = useRefCache();
     const rounded = roundedLeftOnly ? "rounded-l-md" : "rounded-md";
 
     if (value.type === "Property") {
@@ -25,14 +24,14 @@ export const EntitySymbol: React.FunctionComponent<{
             </span>
         );
     } else if (value.type === "EntryType") {
-        const entryTypeColor = mdtContext.refCache.entryTypes[value.id]?.color ?? api.EntryTypeColor.Default;
+        const entryTypeColor = refCache.entryTypes[value.id]?.color ?? api.EntryTypeColor.Default;
         return (
             <span className={`${rounded} py-[3px] px-2 ${defaultBg} ${selected ? '!bg-sky-300' : ''} ${className}`} style={{color: api.entryTypeColors[entryTypeColor][2]}}>
                 <span className="text-xs inline-block min-w-[1.4em] text-center"><Icon icon="square-fill"/></span>
             </span>
         );
     } else if (value.type === "Entry") {
-        const entryTypeData = mdtContext.refCache.entryTypes[mdtContext.refCache.entries[value.id]?.entryType.id];
+        const entryTypeData = refCache.entryTypes[refCache.entries[value.id]?.entryType.id];
         const entryTypeColor = api.entryTypeColors[entryTypeData?.color] ?? api.EntryTypeColor.Default;
         return (
             <span

--- a/frontend/components/widgets/EntryLink.tsx
+++ b/frontend/components/widgets/EntryLink.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { api, useSiteData } from "lib/api";
+import { api, useRefCache, useSiteData } from "lib/api";
 import { DEVELOPMENT_MODE } from "lib/config";
 import { Tooltip } from "components/widgets/Tooltip";
 import { MDTContext } from "components/markdown-mdt/mdt";
@@ -18,8 +18,8 @@ interface Props {
  */
 export const EntryLink: React.FunctionComponent<Props> = (props) => {
     const { site } = useSiteData();
+    const refCache = useRefCache();
 
-    const refCache = props.mdtContext.refCache;
     const entry: undefined|(NonNullable<api.EntryData["referenceCache"]>["entries"]["entryId"]) =
         api.isVNID(props.entryKey) ? refCache.entries[props.entryKey]
         : Object.values(refCache.entries).find(e => e.friendlyId === props.entryKey);

--- a/frontend/components/widgets/EntryTooltipContent.tsx
+++ b/frontend/components/widgets/EntryTooltipContent.tsx
@@ -1,6 +1,8 @@
-import { type VNID } from "neolace-api";
-import Link from "next/link";
 import React from "react";
+import Link from "next/link";
+import { type VNID } from "neolace-api";
+
+import { useRefCache } from "lib/api";
 import { InlineMDT, type MDTContext } from "../markdown-mdt/mdt";
 
 interface Props {
@@ -12,7 +14,7 @@ interface Props {
  * The content to display in a tooltip when hovering over an entry link (or a node in the graph).
  */
 export const EntryTooltipContent: React.FunctionComponent<Props> = (props: Props) => {
-    const refCache = props.mdtContext.refCache;
+    const refCache = useRefCache();
     const entry = refCache.entries[props.entryId];
     return entry ? <>
         <span className="text-base my-1">

--- a/frontend/components/widgets/EntryValue.tsx
+++ b/frontend/components/widgets/EntryValue.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { api, useSiteData } from "lib/api";
+import { api, useRefCache, useSiteData } from "lib/api";
 import { DEVELOPMENT_MODE } from "lib/config";
 import { Tooltip } from "components/widgets/Tooltip";
 import { MDTContext } from "components/markdown-mdt/mdt";
@@ -17,8 +17,8 @@ interface Props {
  */
 export const EntryValue: React.FunctionComponent<Props> = (props) => {
     const { site } = useSiteData();
+    const refCache = useRefCache();
 
-    const refCache = props.mdtContext.refCache;
     const entry: undefined | (NonNullable<api.EntryData["referenceCache"]>["entries"]["entryId"]) =
         refCache.entries[props.entryId];
     if (entry === undefined) {

--- a/frontend/components/widgets/LookupImage.tsx
+++ b/frontend/components/widgets/LookupImage.tsx
@@ -7,7 +7,7 @@ import Image from "next/future/image";
 import Link from "next/link";
 import { ImageDisplayFormat } from "neolace-api";
 
-import { api } from "lib/api";
+import { api, useRefCache } from "lib/api";
 import { imgThumbnailLoader } from "lib/config";
 import { InlineMDT, MDTContext } from "../markdown-mdt/mdt";
 import { RatioBox } from "./ratio-box";
@@ -18,13 +18,13 @@ const OptionalLink = (
     props: {
         children: React.ReactNode;
         href?: api.EntryValue | api.StringValue;
-        mdtContext: MDTContext;
         className: string;
     },
 ) => {
+    const refCache = useRefCache();
     if (props.href) {
         if (props.href.type === "Entry") {
-            const entry: undefined|(NonNullable<api.EntryData["referenceCache"]>["entries"]["entryId"]) = props.mdtContext.refCache.entries[props.href.id];
+            const entry: undefined|(NonNullable<api.EntryData["referenceCache"]>["entries"]["entryId"]) = refCache.entries[props.href.id];
             const url = "/entry/" + (entry?.friendlyId || props.href.id);
             return (
                 <Link href={url} className={props.className}>
@@ -52,10 +52,11 @@ interface ImageProps {
  * Render a Lookup Value that is an image
  */
 export const LookupImage: React.FunctionComponent<ImageProps> = (props) => {
+    const refCache = useRefCache();
     const { value } = props;
     const ratio = value.width && value.height ? value.width / value.height : undefined;
 
-    const imgEntryData = props.mdtContext.refCache.entries[value.entryId];
+    const imgEntryData = refCache.entries[value.entryId];
     const caption = (
         value.caption?.value === "" ? null :  // If caption is an empty string, don't display anything
         value.caption ? <LookupValue value={value.caption} mdtContext={props.mdtContext} /> 
@@ -64,7 +65,7 @@ export const LookupImage: React.FunctionComponent<ImageProps> = (props) => {
 
     if (value.format === api.ImageDisplayFormat.PlainLogo) {
         return <div className="w-full mt-2 mb-1" style={{maxWidth: `${value.maxWidth ?? 400}px`}}>
-            <OptionalLink href={value.link} mdtContext={props.mdtContext} className="">
+            <OptionalLink href={value.link} className="">
                 <Image
                     src={value.imageUrl}
                     loader={imgThumbnailLoader}
@@ -79,7 +80,7 @@ export const LookupImage: React.FunctionComponent<ImageProps> = (props) => {
             <div className="md:clear-right"></div> {/* TODO: make this way of clearing text+images optional?, just have md:clear-right applied to the div below */}
             <div className="w-full md:w-1/3 lg:w-1/4 md:float-right border-2 border-gray-400 md:ml-4 mb-2">
                 <RatioBox ratio={ratio}>
-                    <OptionalLink href={value.link} mdtContext={props.mdtContext} className="relative left-0 top-0 w-full h-full block">
+                    <OptionalLink href={value.link} className="relative left-0 top-0 w-full h-full block">
                         {/* A blurry representation of the image, shown while it is loading. */}
                         <Blurhash hash={value.blurHash ?? ""} width="100%" height="100%" />
                         {/* the image: */}
@@ -102,7 +103,7 @@ export const LookupImage: React.FunctionComponent<ImageProps> = (props) => {
         </>
     } else if (value.format === ImageDisplayFormat.Normal) {
         // Thumbnail:
-        return <OptionalLink href={value.link} mdtContext={props.mdtContext} className="block max-w-full relative">
+        return <OptionalLink href={value.link} className="block max-w-full relative">
             {/* A blurry representation of the image, shown while it is loading. */}
             <Blurhash hash={value.blurHash ?? ""} width="100%" height="100%" className="opacity-30" />
             {/* the image: */}
@@ -118,7 +119,7 @@ export const LookupImage: React.FunctionComponent<ImageProps> = (props) => {
         </OptionalLink>;
     } else {
         // Thumbnail:
-        return <OptionalLink href={value.link} mdtContext={props.mdtContext} className="inline-block h-20 w-20 border-2 border-gray-500 rounded-md relative">
+        return <OptionalLink href={value.link} className="inline-block h-20 w-20 border-2 border-gray-500 rounded-md relative">
             {/* A blurry representation of the image, shown while it is loading. */}
             <Blurhash hash={value.blurHash ?? ""} width="100%" height="100%" className="opacity-30" />
             {/* the image: */}
@@ -133,4 +134,3 @@ export const LookupImage: React.FunctionComponent<ImageProps> = (props) => {
         </OptionalLink>;
     }
 };
- 

--- a/frontend/components/widgets/LookupValue.tsx
+++ b/frontend/components/widgets/LookupValue.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Link from "next/link";
 import { FormattedListParts, FormattedMessage } from "react-intl";
 
-import { api, useSiteData } from "lib/api";
+import { api, useRefCache } from "lib/api";
 import { Tooltip } from "components/widgets/Tooltip";
 import { InlineMDT, MDTContext } from "../markdown-mdt/mdt";
 import { LookupImage } from "./LookupImage";
@@ -39,7 +39,7 @@ interface LookupValueProps {
  * Render a Lookup Value (computed/query value, such as all the "properties" shown on an entry's page)
  */
 export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) => {
-    const { site } = useSiteData();
+    const refCache = useRefCache();
 
     // When the entry loads, the data gets refreshed from the server but is often identical. This will cause a useless
     // update of the whole React tree. We can avoid this by using JSON.stringify to check if the value has actually
@@ -110,7 +110,7 @@ export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) =>
                 />;
                 if (value.source) {
                     if (value.source.entryId) {
-                        const entryKey = props.mdtContext.refCache.entries[value.source.entryId]?.friendlyId ?? props.mdtContext.entryId;
+                        const entryKey = refCache.entries[value.source.entryId]?.friendlyId ?? props.mdtContext.entryId;
                         moreLink = <Link key="more" href={`/entry/${entryKey}/lookup?e=${encodeURIComponent(value.source.expr)}`}>{moreLink}</Link>;
                     } else {
                         moreLink = <Link key="more" href={`/lookup?e=${encodeURIComponent(value.source.expr)}`}>{moreLink}</Link>;
@@ -138,8 +138,8 @@ export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) =>
             return <EntryValue entryId={value.id} mdtContext={props.mdtContext} />;
         }
         case "EntryType": {
-            const entryTypeName = props.mdtContext.refCache.entryTypes[value.id]?.name ?? value.id;
-            const entryTypeColor = props.mdtContext.refCache.entryTypes[value.id]?.color ?? api.EntryTypeColor.Default;
+            const entryTypeName = refCache.entryTypes[value.id]?.name ?? value.id;
+            const entryTypeColor = refCache.entryTypes[value.id]?.color ?? api.EntryTypeColor.Default;
             return <span className="text-sm font-medium font-sans">
                 <span className={`rounded-l-md py-[3px] px-2 bg-gray-200`} style={{color: api.entryTypeColors[entryTypeColor][2]}}>
                     <span className="text-xs inline-block min-w-[1.4em] text-center"><Icon icon="square-fill"/></span>
@@ -161,7 +161,7 @@ export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) =>
             );
         }
         case "Property": {
-            const prop = props.mdtContext.refCache.properties[value.id];
+            const prop = refCache.properties[value.id];
             if (prop === undefined) {
                 // return <Link href={`/prop/${value.id}`}><a className="text-red-700 font-bold">{value.id}</a></Link>
                 return <span className="text-red-700 font-bold">{value.id}</span>;

--- a/frontend/lib/api-data/LoookupExpression.ts
+++ b/frontend/lib/api-data/LoookupExpression.ts
@@ -3,6 +3,7 @@ import useSWR from "swr";
 
 import { client } from "lib/api-client";
 import { useSiteData } from "./SiteData";
+import { useRefCache } from "./ReferenceCache";
 
 /**
  * React hook to evaluate a lookup expression
@@ -11,11 +12,20 @@ import { useSiteData } from "./SiteData";
  export function useLookupExpression(
     expr: string,
     options: { entryId?: api.VNID; pageSize?: number } = {},
-): { result: api.EvaluateLookupData | undefined; error: api.ApiError } {
+): { resultValue: api.AnyLookupValue | undefined; newReferenceCache: api.ReferenceCacheData; foundInCache: boolean; error?: api.ApiError } {
     const { site } = useSiteData();
+
+    const refCache = useRefCache();
+
+    const valueFromCache = refCache.lookups.find((x) => x.entryContext === options.entryId && x.lookupExpression === expr);
+
     // TODO: include an entry revision number in this ID
-    const key = `lookup:${site.shortId}:${options.entryId ?? "none"}:${options.pageSize ?? "default"}:no-draft:${expr}`;
+    const key = valueFromCache !== undefined ? "" : `lookup:${site.shortId}:${options.entryId ?? "none"}:${options.pageSize ?? "default"}:no-draft:${expr}`;
     const { data, error } = useSWR(key, async () => {
+        if (key === "") {
+            // The lookup value was found in the reference cache. Do not query the server.
+            return undefined;
+        }
         if (expr.trim() === "") {
             // If there is no expression, don't bother hitting the API:
             return {
@@ -35,5 +45,20 @@ import { useSiteData } from "./SiteData";
     }, {
         // refreshInterval: 10 * 60_000,
     });
-    return { result: data, error };
+
+    if (valueFromCache !== undefined) {
+        return {
+            foundInCache: true,
+            resultValue: valueFromCache.value,
+            newReferenceCache: refCache,
+            error: undefined,
+        }
+    } else {
+        return {
+            foundInCache: false,
+            resultValue: data?.resultValue,
+            newReferenceCache: data?.referenceCache ?? refCache,
+            error,
+        };
+    }
 }

--- a/frontend/lib/api-data/ReferenceCache.ts
+++ b/frontend/lib/api-data/ReferenceCache.ts
@@ -1,0 +1,42 @@
+import React from "react";
+
+import * as api from "neolace-api";
+import { useDraft } from "./DraftData";
+
+/**
+ * In this context, a "reference cache" is available to provide data on any Entry, Entry Type, or Property that is
+ * referenced. For example, in the context of an Entry A that links to Entry B, the reference cache will include some
+ * details about Entry B such as its Name and friendly ID, so that the link to it can be properly displayed within Entry
+ * A.
+ */
+export const RefCacheContext = React.createContext<
+    { refCache?: api.ReferenceCacheData /*, parentRefCache?: api.ReferenceCacheData*/ }
+>({
+    // Default values for this context:
+    refCache: undefined,
+});
+
+/**
+ * React hook to get the reference cache data, if available in this context
+ * @returns
+ */
+export function useRefCache(options: Record<string, unknown> = {}): api.ReferenceCacheData {
+    const context = React.useContext(RefCacheContext);
+    const [draft, unsavedEdits] = useDraft();
+
+    return React.useMemo(() => {
+        const base = context.refCache ?? {
+            entries: {},
+            entryTypes: {},
+            lookups: [],
+            properties: {},
+        };
+        if (draft?.edits || unsavedEdits.length > 0) {
+            // If we're in some context where there are edits from the draft or an editor,
+            // apply those edits to the reference cache too.
+            const newRefCache = api.applyEditsToReferenceCache(base, [...(draft?.edits ?? []), ...unsavedEdits]);
+            return newRefCache;
+        }
+        return base;
+    }, [context?.refCache, draft?.edits, unsavedEdits]);
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -7,6 +7,7 @@ export * from "lib/api-data/Entry";
 export * from "lib/api-data/EditableEntry";
 export * from "lib/api-data/LoookupExpression";
 export * from "lib/api-data/Permissions";
+export * from "lib/api-data/ReferenceCache";
 export * from "lib/api-data/Schema";
 export * from "lib/api-data/SiteData";
 export * from "lib/api-data/User";
@@ -16,24 +17,9 @@ export const NEW = "_";
 export type NEW = typeof NEW;
 
 // /**
-//  * In this context, a "reference cache" is available to provide data on any Entry, Entry Type, or Property that is
-//  * referenced. For example, in the context of an Entry A that links to Entry B, the reference cache will include some
-//  * details about Entry B such as its Name and friendly ID, so that the link to it can be properly displayed within Entry
-//  * A.
-//  */
-//  export const RefCacheContext = React.createContext<{refCache?: api.ReferenceCacheData, parentRefCache?: api.ReferenceCacheData}>({
-//     // Default values for this context:
-//     refCache: undefined,
-// });
-
-// /**
 //  * In this context, there is a "current entry ID". e.g. on an entry page, this is the ID of the entry being viewed.
 //  */
 // export const EntryContext = React.createContext<{entryId: VNID|undefined}>({
 //     // Default values for this context:
 //     entryId: undefined,
 // });
-
-
-// TODO: a useRefCache() hook that uses the RefCacheContext plus applies any edits from the draft to the reference
-// cache.

--- a/frontend/pages/site/[siteHost]/entry/[entryId]/lookup.tsx
+++ b/frontend/pages/site/[siteHost]/entry/[entryId]/lookup.tsx
@@ -3,7 +3,7 @@ import { FormattedMessage } from "react-intl";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Link from "next/link";
 import { ParsedUrlQuery } from "querystring";
-import { api, client, getSiteData } from "lib/api";
+import { api, client, getSiteData, RefCacheContext } from "lib/api";
 
 import { SiteDataProvider, SitePage } from "components/SitePage";
 import { LookupExpressionInput } from "components/form-input";
@@ -46,53 +46,54 @@ const EvaluateLookupPage: NextPage<PageProps> = function (props) {
 
     const mdtContext = React.useMemo(() => new MDTContext({
         entryId: props.entry.id,
-        refCache: props.entry.referenceCache,
-    }), [props.entry.id, props.entry.referenceCache]);
+    }), [props.entry.id]);
 
     return (
         <SiteDataProvider sitePreloaded={props.sitePreloaded}>
-            <SitePage
-                leftNavTopSlot={[
-                    {id: "entryName", priority: 20, content: <>
-                        <br/>
-                        <strong>{props.entry.name}</strong>
-                    </>},
-                    {id: "entryId", priority: 21, content: <>
-                        <code id="entry-id" data-entry-id={props.entry.id} className="font-mono font-light hidden">{props.entry.friendlyId}</code>
-                    </>},
-                    {id: "tableOfContents", priority: 50, content: <>
-                        <ul id="left-toc-headings">
-                            <li><Link  href={`/entry/${props.entry.friendlyId}#summary`}><FormattedMessage id="RrCui3" defaultMessage="Summary"/></Link></li>
-                            <li className={`${hasProps || "hidden"}`}><Link href={`/entry/${props.entry.friendlyId}#properties`}><FormattedMessage id="aI80kg" defaultMessage="Properties"/></Link></li>
-                            {
-                                props.entry.features?.Article?.headings.map(heading =>
-                                    <li key={heading.id}><Link href={`/entry/${props.entry.friendlyId}#h-${heading.id}`}>{heading.title}</Link></li>
-                                )
-                            }
-                        </ul>
-                    </>},
-                ]}
-                title={props.entry.name}
-            >
-                <h1>{props.entry.name}</h1>
+            <RefCacheContext.Provider value={{refCache: props.entry.referenceCache}}>
+                <SitePage
+                    leftNavTopSlot={[
+                        {id: "entryName", priority: 20, content: <>
+                            <br/>
+                            <strong>{props.entry.name}</strong>
+                        </>},
+                        {id: "entryId", priority: 21, content: <>
+                            <code id="entry-id" data-entry-id={props.entry.id} className="font-mono font-light hidden">{props.entry.friendlyId}</code>
+                        </>},
+                        {id: "tableOfContents", priority: 50, content: <>
+                            <ul id="left-toc-headings">
+                                <li><Link  href={`/entry/${props.entry.friendlyId}#summary`}><FormattedMessage id="RrCui3" defaultMessage="Summary"/></Link></li>
+                                <li className={`${hasProps || "hidden"}`}><Link href={`/entry/${props.entry.friendlyId}#properties`}><FormattedMessage id="aI80kg" defaultMessage="Properties"/></Link></li>
+                                {
+                                    props.entry.features?.Article?.headings.map(heading =>
+                                        <li key={heading.id}><Link href={`/entry/${props.entry.friendlyId}#h-${heading.id}`}>{heading.title}</Link></li>
+                                    )
+                                }
+                            </ul>
+                        </>},
+                    ]}
+                    title={props.entry.name}
+                >
+                    <h1>{props.entry.name}</h1>
 
-                <LookupExpressionInput
-                    value={editingLookupExpression}
-                    onChange={handleLookupExpressionChange}
-                    onFinishedEdits={handleFinishedChangingLookupExpression}
-                    placeholder={defineMessage({id: 'Uowwem', defaultMessage: "Enter a lookup expression..."})}
-                />
+                    <LookupExpressionInput
+                        value={editingLookupExpression}
+                        onChange={handleLookupExpressionChange}
+                        onFinishedEdits={handleFinishedChangingLookupExpression}
+                        placeholder={defineMessage({id: 'Uowwem', defaultMessage: "Enter a lookup expression..."})}
+                    />
 
-                <p><FormattedMessage id="vBiQpy" defaultMessage="Result:" /></p>
-                <div className={activeLookupExpression !== editingLookupExpression ? `opacity-50` : ``}>
-                    {
-                        activeLookupExpression ?
-                            <LookupEvaluatorWithPagination expr={activeLookupExpression} mdtContext={mdtContext} />
-                        :
-                            <FormattedMessage id="++0Uwo" defaultMessage="Enter a lookup expression above to see the result." />
-                    }
-                </div>
-            </SitePage>
+                    <p><FormattedMessage id="vBiQpy" defaultMessage="Result:" /></p>
+                    <div className={activeLookupExpression !== editingLookupExpression ? `opacity-50` : ``}>
+                        {
+                            activeLookupExpression ?
+                                <LookupEvaluatorWithPagination expr={activeLookupExpression} mdtContext={mdtContext} />
+                            :
+                                <FormattedMessage id="++0Uwo" defaultMessage="Enter a lookup expression above to see the result." />
+                        }
+                    </div>
+                </SitePage>
+            </RefCacheContext.Provider>
         </SiteDataProvider>
     );
 }

--- a/frontend/pages/site/[siteHost]/index.tsx
+++ b/frontend/pages/site/[siteHost]/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import { ParsedUrlQuery } from "querystring";
-import { api, client, getSiteData, SiteData } from "lib/api";
+import { api, client, getSiteData, RefCacheContext, SiteData } from "lib/api";
 
 import { SiteDataProvider, SitePage } from "components/SitePage";
 import { MDTContext, RenderMDT } from "components/markdown-mdt/mdt";
@@ -20,34 +20,35 @@ interface PageUrlQuery extends ParsedUrlQuery {
 const HomePage: NextPage<PageProps> = function (props) {
 
     
-    const mdtContext = React.useMemo(() => new MDTContext({
-        entryId: undefined,
-        refCache: props.refCache,
-    }), [props.refCache]);
+    const mdtContext = React.useMemo(() => new MDTContext({ entryId: undefined, }), []);
 
-    return (<SiteDataProvider sitePreloaded={props.site}>
-        <SitePage title={props.site.name}>
-            {/* Below, 100vh-11.6rem pushes the footer down to the bottom of the screen but prevents scrolling if there's only a single line in the footer */}
-            <div className="max-w-6xl mx-auto neo-typography md:min-h-[calc(100vh-11.6rem)]">
-                {props.homepageMD ?
-                    <RenderMDT mdt={props.homepageMD} context={mdtContext} />
-                :
-                    <>
-                        <h1>
-                            <FormattedMessage id="vfakHv" defaultMessage="Welcome to {siteName}" values={{siteName: props.site.name}}/>
-                        </h1>
-                        <p>
-                            <FormattedMessage
-                                id="Gb43IT"
-                                defaultMessage="This site is powered by Neolace. If this is your site, you should customize this home page to say what you'd like."
-                                description="A default homepage description, if no home page text has been set."
-                            />
-                        </p>
-                    </>
-                }
-            </div>
-        </SitePage>
-    </SiteDataProvider>);
+    return (
+        <SiteDataProvider sitePreloaded={props.site}>
+            <RefCacheContext.Provider value={{refCache: props.refCache}}>
+                <SitePage title={props.site.name}>
+                    {/* Below, 100vh-11.6rem pushes the footer down to the bottom of the screen but prevents scrolling if there's only a single line in the footer */}
+                    <div className="max-w-6xl mx-auto neo-typography md:min-h-[calc(100vh-11.6rem)]">
+                        {props.homepageMD ?
+                            <RenderMDT mdt={props.homepageMD} context={mdtContext} />
+                        :
+                            <>
+                                <h1>
+                                    <FormattedMessage id="vfakHv" defaultMessage="Welcome to {siteName}" values={{siteName: props.site.name}}/>
+                                </h1>
+                                <p>
+                                    <FormattedMessage
+                                        id="Gb43IT"
+                                        defaultMessage="This site is powered by Neolace. If this is your site, you should customize this home page to say what you'd like."
+                                        description="A default homepage description, if no home page text has been set."
+                                    />
+                                </p>
+                            </>
+                        }
+                    </div>
+                </SitePage>
+            </RefCacheContext.Provider>
+        </SiteDataProvider>
+    );
 }
 
 export default HomePage;

--- a/frontend/pages/site/[siteHost]/lookup.tsx
+++ b/frontend/pages/site/[siteHost]/lookup.tsx
@@ -45,7 +45,7 @@ const EvaluateLookupPage: NextPage<PageProps> = function (props) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [router.isReady, router.asPath]);
 
-    const mdtContext = React.useMemo(() => new MDTContext({ entryId: undefined, refCache: undefined }), []);
+    const mdtContext = React.useMemo(() => new MDTContext({ entryId: undefined }), []);
 
     const title = intl.formatMessage({ defaultMessage: "Lookup", id: "VzW9jr" });
 

--- a/frontend/pages/site/[siteHost]/ui.tsx
+++ b/frontend/pages/site/[siteHost]/ui.tsx
@@ -22,7 +22,7 @@ import {
 import { defineMessage, noTranslationNeeded } from "components/utils/i18n";
 import { Tab, TabBarRouter } from "components/widgets/Tabs";
 import { LookupValue } from "components/widgets/LookupValue";
-import { api } from "lib/api";
+import { api, RefCacheContext } from "lib/api";
 import { MDTContext } from "components/markdown-mdt/mdt";
 import { DEVELOPMENT_MODE } from "lib/config";
 
@@ -47,31 +47,41 @@ const UiDemoPage: NextPage = function (props) {
         return <FourOhFour />;
     }
 
-    const demoMDTContext = new MDTContext({
-        refCache: {
-            entries: {
-                "_12345": {
-                    id: api.VNID("_12345"),
-                    description: "Description of the entry goes here.",
-                    entryType: { id: api.VNID("_demoType") },
-                    friendlyId: "demo-entry",
-                    name: "Demo Entry",
-                },
+    const demoMDTContext = new MDTContext({});
+    const demoRefCache: api.ReferenceCacheData = {
+        entries: {
+            "_12345": {
+                id: api.VNID("_12345"),
+                description: "Description of the entry goes here.",
+                entryType: { id: api.VNID("_demoType") },
+                friendlyId: "demo-entry",
+                name: "Demo Entry",
             },
-            entryTypes: {
-                "_demoType": {
-                    id: api.VNID("_demoType"),
-                    name: "Type goes here",
-                    abbreviation: "D",
-                    color: api.EntryTypeColor.Cyan,
-                },
-            },
-            properties: {},
-            lookups: [],
         },
-    });
+        entryTypes: {
+            "_demoType": {
+                id: api.VNID("_demoType"),
+                name: "Type goes here",
+                abbreviation: "D",
+                color: api.EntryTypeColor.Cyan,
+            },
+        },
+        properties: {
+            "_demoProp": {
+                name: "Demoness",
+                description: "To what extent this is a demo.",
+                id: api.VNID("_demoProp"),
+                type: api.PropertyType.Value,
+                standardURL: "",
+                rank: 1,
+                displayAs: "",
+            }
+        },
+        lookups: [],
+    };
 
     return (
+        <RefCacheContext.Provider value={{refCache: demoRefCache}}>
         <SitePage title="UI Demos">
             <h1 className="text-3xl font-semibold">UI Demos</h1>
 
@@ -262,6 +272,7 @@ const UiDemoPage: NextPage = function (props) {
                 </tbody>
             </table>
         </SitePage>
+        </RefCacheContext.Provider>
     );
 };
 


### PR DESCRIPTION
This makes "reference cache" data available more easily, via a hook/context, instead of keeping it in `MDTContext` objects which have to be manually passed to child components.

In order to make this change easier to test and to avoid refactoring too much at once, the overall usage of `MDTContext` is still unchanged. Future refactors will aim to get rid of it completely.

This approach is preferable not only because it requires passing fewer objects around as parameters, but also because the context/hook are aware of things like edits from the draft, and this updated design allows for a smart fallback where things are loaded from the reference cache *if possible* and otherwise loaded from the server.