### PR TITLE
Add support for inline footnotes in the visual editor

### DIFF
--- a/frontend/components/slate-editor/slate-mdt.tsx
+++ b/frontend/components/slate-editor/slate-mdt.tsx
@@ -216,6 +216,8 @@ export function renderElement({ element, children, attributes }: RenderElementPr
             return <ul {...attributes}>{children}</ul>;
         case "list_item":
             return <li {...attributes}>{children}</li>;
+        case "footnote_inline":
+            return <span {...attributes} className="bg-slate-100 border p-1 text-sm"><span className="text-xs opacity-70" contentEditable={false}>Footnote:</span> {children}</span>
         default:
             return (
                 <span className="border-red-100 border-[1px] text-red-700">{`Unknown MDT node "${element.type}"`}</span>

--- a/frontend/components/slate-editor/slate.ts
+++ b/frontend/components/slate-editor/slate.ts
@@ -348,6 +348,8 @@ export function slateDocToStringValue(node: NeolaceSlateElement[], escape: Escap
             result += '`' + slateDocToStringValue(n.children, EscapeMode.PlainText) + '`';
         } else if (n.type === "lookup_inline") {
             result += `{ ` + slateDocToStringValue(n.children, EscapeMode.PlainText) + ` }`;
+        } else if (n.type === "footnote_inline") {
+            result += `^[ ` + slateDocToStringValue(n.children, EscapeMode.MDT) + ` ]`;
         } else if (n.type === "custom-void-entry") {
             result += `entry("${(n as VoidEntryNode).entryId}")`;
         } else if (n.type === "custom-void-property") {


### PR DESCRIPTION
Before, you couldn't edit footnotes in the visual editor:

![Screen Shot 2022-10-16 at 3 45 36 PM](https://user-images.githubusercontent.com/945577/196062027-97888a20-f7ef-41e7-bc40-c5b205dce295.png)

Now you can:

![Screen Shot 2022-10-16 at 3 46 04 PM](https://user-images.githubusercontent.com/945577/196062040-b71881f2-eec7-4b06-bfbc-759c3ec59a7a.png)


