### PR TITLE
feat(backend): sort() will always sort NULL values to be last

### DIFF
--- a/backend/neolace/core/lookup/expressions/functions/sort.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/sort.test.ts
@@ -52,6 +52,17 @@ group("sort.ts", () => {
         );
     });
 
+    test("NULL values always sort last", async () => {
+        await checkSort(
+            `[18, -10, 5, null, null, null, 64, 0, -3, -18].sort()`,
+            `[-18, -10, -3, 0, 5, 18, 64, null, null, null]`,
+        );
+        await checkSort(
+            `[18, null, 5, 64, 0, -3, -10, null, -18].sort(reverse=true)`,
+            `[64, 18, 5, 0, -3, -10, -18, null, null]`,
+        );
+    });
+
     test("Sorting large integers", async () => {
         await checkSort(
             `[

--- a/backend/neolace/core/lookup/expressions/functions/sort.ts
+++ b/backend/neolace/core/lookup/expressions/functions/sort.ts
@@ -1,5 +1,5 @@
 import { LookupExpression } from "../base.ts";
-import { BooleanValue, isIterableValue, LambdaValue, LazyIterableValue, LookupValue } from "../../values.ts";
+import { BooleanValue, isIterableValue, LambdaValue, LazyIterableValue, LookupValue, NullValue } from "../../values.ts";
 import { LookupEvaluationError } from "../../errors.ts";
 import { LookupContext } from "../../context.ts";
 import { LookupFunctionWithArgs } from "./base.ts";
@@ -62,11 +62,12 @@ export class Sort extends LookupFunctionWithArgs {
                 values.push([value, value]);
             }
         }
-        if (reverse) {
-            values.sort((a, b) => b[1].compareTo(a[1]));
-        } else {
-            values.sort((a, b) => a[1].compareTo(b[1]));
-        }
+
+        // We always sort NULL values to the end, regardless of the 'reverse' direction or not.
+        const doSort = (a: LookupValue, b: LookupValue, reverse?: boolean) => (
+            a instanceof NullValue ? 1 : b instanceof NullValue ? -1 : reverse ? b.compareTo(a) : a.compareTo(b)
+        );
+        values.sort((a, b) => doSort(a[1], b[1], reverse));
 
         return new LazyIterableValue({
             context,


### PR DESCRIPTION
Usually people won't want to see NULL values first in any case.