### PR TITLE
New lookup feature: .get() can retrieve a property from multiple entries

### DIFF
--- a/backend/neolace/core/lookup/expressions/functions/get.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/get.test.ts
@@ -70,7 +70,26 @@ group("get.ts", () => {
     });
 
     group("get() - value property, multiple entries", () => {
-        // TODO: implement this
+        test(`get() can retrieve a property value for multiple entries`, async () => {
+            // Get the scientific name for all pines:
+            const value = await context.evaluateExprConcrete(
+                `
+                entry("${defaultData.entries.genusPinus.id}").descendants()
+                .get(prop=prop("${defaultData.schema.properties._propScientificName.id}"))
+                .sort()
+            `,
+                defaultData.entries.ponderosaPine.id,
+            );
+
+            assertInstanceOf(value, PageValue);
+            assertEquals(value.values, [
+                // Currently only four entries in the default data set have scientific names:
+                new StringValue("Pinus banksiana"),
+                new StringValue("Pinus densiflora"),
+                new StringValue("Pinus pinea"),
+                new StringValue("Pinus ponderosa"),
+            ]);
+        });
     });
 
     group("get() - auto property", () => {

--- a/backend/neolace/sample-data/plantdb/content.ts
+++ b/backend/neolace/sample-data/plantdb/content.ts
@@ -256,6 +256,15 @@ export const makePlantDbContent: EditList = [
             propertyFactId: VNID(),
         },
     },
+    {
+        code: "AddPropertyValue",
+        data: {
+            entryId: entryData.stonePine.id,
+            propertyId: schema.properties._propScientificName.id,
+            valueExpression: `"Pinus pinea"`,
+            propertyFactId: VNID(),
+        },
+    },
     // Jack Pine
     {
         code: "CreateEntry",
@@ -276,6 +285,15 @@ export const makePlantDbContent: EditList = [
             propertyFactId: VNID(),
         },
     },
+    {
+        code: "AddPropertyValue",
+        data: {
+            entryId: entryData.jackPine.id,
+            propertyId: schema.properties._propScientificName.id,
+            valueExpression: `"Pinus banksiana"`,
+            propertyFactId: VNID(),
+        },
+    },
     // Japanese Red Pine
     {
         code: "CreateEntry",
@@ -293,6 +311,15 @@ export const makePlantDbContent: EditList = [
             entryId: entryData.japaneseRedPine.id,
             propertyId: schema.properties._parentGenus.id,
             valueExpression: `entry("${entryData.genusPinus.id}")`,
+            propertyFactId: VNID(),
+        },
+    },
+    {
+        code: "AddPropertyValue",
+        data: {
+            entryId: entryData.japaneseRedPine.id,
+            propertyId: schema.properties._propScientificName.id,
+            valueExpression: `"Pinus densiflora"`,
             propertyFactId: VNID(),
         },
     },


### PR DESCRIPTION
Before, `.get()` would only work with a single entry. Now it can work with multiple entries.