### PR TITLE
New withDetail() lookup function

### DIFF
--- a/backend/neolace/core/lookup/expressions.ts
+++ b/backend/neolace/core/lookup/expressions.ts
@@ -27,6 +27,7 @@ export { Range } from "./expressions/functions/range.ts";
 export { ReverseProperty } from "./expressions/functions/reverse.ts";
 export { Slice } from "./expressions/functions/slice.ts";
 export { Sort } from "./expressions/functions/sort.ts";
+export { WithDetail } from "./expressions/functions/withDetail.ts";
 // Non-functions:
 export { Lambda } from "./expressions/lambda.ts";
 export { List } from "./expressions/list-expr.ts";

--- a/backend/neolace/core/lookup/expressions/functions/withDetail.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/withDetail.test.ts
@@ -1,0 +1,61 @@
+import { assertEquals, group, setTestIsolation, test, TestLookupContext } from "neolace/lib/tests.ts";
+import { WithDetail } from "./withDetail.ts";
+import { AnnotatedValue, EntryValue, PageValue, PropertyValue, StringValue } from "../../values.ts";
+import { This } from "../this.ts";
+import { LiteralExpression } from "../literal-expr.ts";
+import { List } from "../list-expr.ts";
+
+group("withDetails()", () => {
+    // These tests are read-only so don't need isolation, but do use the default plantDB example data:
+    const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
+    const siteId = defaultData.site.id;
+    const ponderosaPine = defaultData.entries.ponderosaPine;
+    const jackPine = defaultData.entries.jackPine;
+    const context = new TestLookupContext({ siteId, entryId: ponderosaPine.id, defaultPageSize: 15n });
+
+    const scientificNameProp = new LiteralExpression(
+        new PropertyValue(defaultData.schema.properties._propScientificName.id),
+    );
+
+    test("It can annotate set of entries with details coming from a property value", async () => {
+        // this is the same as this.andRelated(depth=1)
+        const expression = new WithDetail(
+            new List([
+                new LiteralExpression(new EntryValue(ponderosaPine.id)),
+                new LiteralExpression(new EntryValue(jackPine.id)),
+            ]),
+            { prop: scientificNameProp },
+        );
+        const value = await context.evaluateExprConcrete(expression);
+
+        assertEquals(
+            value,
+            new PageValue(
+                [
+                    new AnnotatedValue(new EntryValue(ponderosaPine.id), {
+                        detail: new StringValue("Pinus ponderosa"),
+                    }),
+                    new AnnotatedValue(new EntryValue(jackPine.id), { detail: new StringValue("Pinus banksiana") }),
+                ],
+                {
+                    pageSize: 15n,
+                    startedAt: 0n,
+                    totalCount: 2n,
+                    sourceExpression: expression,
+                    sourceExpressionEntryId: ponderosaPine.id,
+                },
+            ),
+        );
+    });
+
+    test("It can annotate a single entry with a detail coming from a property value", async () => {
+        // this is the same as this.andRelated(depth=1)
+        const expression = new WithDetail(new This(), { prop: scientificNameProp });
+        const value = await context.evaluateExprConcrete(expression);
+
+        assertEquals(
+            value,
+            new AnnotatedValue(new EntryValue(ponderosaPine.id), { detail: new StringValue("Pinus ponderosa") }),
+        );
+    });
+});

--- a/backend/neolace/core/lookup/expressions/functions/withDetail.ts
+++ b/backend/neolace/core/lookup/expressions/functions/withDetail.ts
@@ -1,0 +1,81 @@
+import { LookupExpression } from "../base.ts";
+import {
+    AnnotatedValue,
+    EntryValue,
+    ErrorValue,
+    isIterableValue,
+    LazyIterableValue,
+    LookupValue,
+} from "../../values.ts";
+import { LookupContext } from "../../context.ts";
+import { LookupFunctionWithArgs } from "./base.ts";
+import { Map } from "./map.ts";
+import { Lambda } from "../lambda.ts";
+import { Variable } from "../variable.ts";
+import { Annotate } from "./annotate.ts";
+import { GetProperty } from "./get.ts";
+import { LookupEvaluationError } from "../../errors.ts";
+import { LiteralExpression } from "../../expressions.ts";
+
+/**
+ * withDetail([entry set], prop=...)
+ *
+ * Given a set of entries, annotate them with a particular property so that the specified property value will be
+ * displayed next to each entry, e.g. entry("canada").withDetail(prop=prop("population")) would display
+ * Canada (38 million)
+ *
+ * This is just a shortcut for
+ * map([entry set], apply=(e -> e.annotate(detail=e.get(prop=...))))
+ *
+ * This can also be used to add a detail annotation to a single entry: entry("...").withDetail(prop=...)
+ */
+export class WithDetail extends LookupFunctionWithArgs {
+    static functionName = "withDetail";
+
+    /** An expression that specifies which entries we want to annotate */
+    public get fromEntriesExpr(): LookupExpression {
+        return this.firstArg;
+    }
+
+    /** An expression that specifies what property we want to retrieve */
+    public get propertyExpr(): LookupExpression {
+        return this.otherArgs["prop"];
+    }
+
+    protected override validateArgs(): void {
+        this.requireArgs(["prop"]);
+    }
+
+    public async getValue(context: LookupContext): Promise<LookupValue> {
+        if (isIterableValue(await this.fromEntriesExpr.getValue(context))) {
+            // TODO: in the future, this could be more optimized, to pre-fetch the property values for all entries instead
+            // of fetching it one at a time per entry within map(). Alternately map() can be made to be able to pre-fetch
+            // values and in that case, it won't be necessary to change this withDetail() function at all.
+            const result = await context.evaluateExpr(
+                new Map(this.fromEntriesExpr, {
+                    apply: new Lambda(
+                        "entry",
+                        new Annotate(new Variable("entry"), {
+                            detail: new GetProperty(new Variable("entry"), { prop: this.propertyExpr }),
+                        }),
+                    ),
+                }),
+            );
+            if (result instanceof ErrorValue) {
+                return result;
+            } else if (!(result instanceof LazyIterableValue)) {
+                throw new LookupEvaluationError("Internal error - expected map() to return a LazyIterableValue");
+            }
+            // And update the source expression so that "show more" links will properly use this withDetail() expression
+            // and not change to show the full "map(...)" expression
+            return result.cloneWithSourceExpression(this, context.entryId);
+        } else {
+            // We also allow .withDetail() to work with a single entry:
+            const entryValue = await this.fromEntriesExpr.getValueAs(EntryValue, context);
+            const expr = new GetProperty(new LiteralExpression(entryValue), { prop: this.propertyExpr });
+            return new AnnotatedValue(entryValue, {
+                detail: await (await context.evaluateExpr(expr)).makeConcrete(),
+            });
+        }
+    }
+}


### PR DESCRIPTION
This new function makes it much simpler to display a list of entries that includes a specific property alongside each one.

Before, to display the fastest gondola of a specific type, it was necessary to write:

```
        entry("tc-trnsprt-cable-3s").descendants().filter(
            entryType=entryType("_ET_INSTANCE")
        ).map(
            apply=(e ->
                e.annotate(
                    detail=e.get(prop=prop("_PROP_ROUTE_CAPACITY_PASSENGERS"))
                )
            )
        ).sort(
            by=(i -> i.detail),
            reverse=true
        ).first()
```

But now one can write:

```
        entry("tc-trnsprt-cable-3s").descendants()
        .filter(entryType=entryType("_ET_INSTANCE"))
        .withDetail(prop=prop("_PROP_ROUTE_CAPACITY_PASSENGERS"))
        .sort(by=(i -> i.detail), reverse=true)
        .first()
```