### PR TITLE
Update GitHub actions and CI workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -179,7 +179,7 @@ jobs:
         uses: tj-actions/branch-names@7f0a69aa8e80f46987e8979c73ac9923d6a3c004
 
       - name: Determine tag to use
-        uses: haya14busa/action-cond@v1.1.0
+        uses: haya14busa/action-cond@dependabot/npm_and_yarn/actions/core-1.9.1
         id: tag-condition
         with:
           # Are we running on main (the default branch) or a PR that will merge into main?


### PR DESCRIPTION
We were getting some deprecation warnings from GitHub actions, so I bumped the version of the `checkout` and `setup-deno` actions that we use. This also bumps to the newest version of Deno.