### PR TITLE
perf(backend): Optimize extended validation of Entry/PropertyFact/etc.

### DIFF
--- a/backend/neolace/api/site/{siteShortId}/entry/index.ts
+++ b/backend/neolace/api/site/{siteShortId}/entry/index.ts
@@ -145,7 +145,6 @@ export class EntryListResource extends NeolaceHttpResource {
                 text: deletePropertyFacts.queryString,
                 parameters: deletePropertyFacts.params,
             });
-            console.log(`Deleting entry features...`);
             log.info(`Deletion part 2/4 - deleting entry features from ${siteShortId}...`);
             await graph._restrictedWrite({
                 text: deleteEntryFeatures.queryString,

--- a/backend/neolace/core/User.ts
+++ b/backend/neolace/core/User.ts
@@ -24,7 +24,7 @@ export class User extends VNodeType {
         fullName: Field.String.Check(check.string.max(100)),
     };
 
-    static async validate(dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(dbObject: RawVNode<typeof this>): Promise<void> {
         // Mostly done automatically by Vertex Framework
         const isHuman = dbObject._labels.includes(HumanUser.label);
         const isBot = dbObject._labels.includes(BotUser.label);

--- a/backend/neolace/core/edit/AppliedEdit.ts
+++ b/backend/neolace/core/edit/AppliedEdit.ts
@@ -1,6 +1,6 @@
 import * as check from "neolace/deps/computed-types.ts";
 import { EditChangeType, getEditType } from "neolace/deps/neolace-api.ts";
-import { Field, FieldValidationError, RawVNode, VNodeType, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
+import { Field, FieldValidationError, RawVNode, VNodeType } from "neolace/deps/vertex-framework.ts";
 import { Entry } from "neolace/core/entry/Entry.ts";
 import { EditSource } from "./EditSource.ts";
 
@@ -41,7 +41,7 @@ export class AppliedEdit extends VNodeType {
 
     static derivedProperties = this.hasDerivedProperties({});
 
-    static async validate(dbObject: RawVNode<typeof AppliedEdit>, _tx: WrappedTransaction): Promise<void> {
+    static override async validate(dbObject: RawVNode<typeof AppliedEdit>): Promise<void> {
         // Validate that "code", "changeType", and "data" are all consistent:
         const editType = getEditType(dbObject.code);
         if (dbObject.changeType !== editType.changeType) {

--- a/backend/neolace/core/edit/Draft.ts
+++ b/backend/neolace/core/edit/Draft.ts
@@ -8,7 +8,6 @@ import {
     RawVNode,
     VirtualPropType,
     VNodeType,
-    WrappedTransaction,
 } from "neolace/deps/vertex-framework.ts";
 import { Entry } from "neolace/core/entry/Entry.ts";
 import { Site } from "neolace/core/Site.ts";
@@ -37,7 +36,7 @@ export class DraftEdit extends VNodeType {
 
     static derivedProperties = this.hasDerivedProperties({});
 
-    static async validate(dbObject: RawVNode<typeof DraftEdit>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(dbObject: RawVNode<typeof DraftEdit>): Promise<void> {
         // Validate that "code", "changeType", and "data" are all consistent:
         const editType = getEditType(dbObject.code);
         if (dbObject.changeType !== editType.changeType) {
@@ -157,7 +156,7 @@ export class Draft extends EditSource {
         hasContentChanges,
     });
 
-    static async validate(_dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(): Promise<void> {
         // We don't verify if user is part of Site, because users can open a Draft then be removed from a Site but
         // their Draft should live on.
     }

--- a/backend/neolace/core/edit/EditSource.ts
+++ b/backend/neolace/core/edit/EditSource.ts
@@ -1,4 +1,4 @@
-import { C, RawVNode, VirtualPropType, VNodeType, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
+import { C, VirtualPropType, VNodeType } from "neolace/deps/vertex-framework.ts";
 import { Site } from "neolace/core/Site.ts";
 
 /**
@@ -31,7 +31,7 @@ export class EditSource extends VNodeType {
         },
     });
 
-    static async validate(_dbObject: RawVNode<typeof EditSource>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(): Promise<void> {
         // No custom validation
     }
 }

--- a/backend/neolace/core/entry/features/Article/ArticleEnabled.ts
+++ b/backend/neolace/core/entry/features/Article/ArticleEnabled.ts
@@ -26,6 +26,6 @@ export class ArticleEnabled extends EnabledFeature {
 
     static derivedProperties = this.hasDerivedProperties({});
 
-    // static async validate(dbObject: RawVNode<typeof this>, tx: WrappedTransaction): Promise<void> {
+    // static async validate(): Promise<void> {
     // }
 }

--- a/backend/neolace/core/entry/features/EnabledFeature.ts
+++ b/backend/neolace/core/entry/features/EnabledFeature.ts
@@ -1,4 +1,4 @@
-import { RawVNode, VNodeType, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
+import { RawVNode, VNodeType } from "neolace/deps/vertex-framework.ts";
 
 /**
  * For each EntryType that supports (enables) a given feature (like Article text), that EntryType will have an
@@ -18,7 +18,7 @@ export class EnabledFeature extends VNodeType {
 
     static derivedProperties = this.hasDerivedProperties({});
 
-    static async validate(dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(dbObject: RawVNode<typeof this>): Promise<void> {
         if (dbObject._labels.length !== 3) {
             throw new Error(
                 `Every EnabledFeature VNode should have exactly three labels: VNode, EnabledFeature, and _________Enabled (a specific feature type)`,

--- a/backend/neolace/core/entry/features/EntryFeatureData.ts
+++ b/backend/neolace/core/entry/features/EntryFeatureData.ts
@@ -1,4 +1,4 @@
-import { RawVNode, VNodeType, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
+import { RawVNode, VNodeType } from "neolace/deps/vertex-framework.ts";
 
 /**
  * Abstract base class for data stored on each Entry related to an "entry feature", which adds capabilities to an
@@ -19,7 +19,7 @@ export class EntryFeatureData extends VNodeType {
 
     static derivedProperties = this.hasDerivedProperties({});
 
-    static async validate(dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(dbObject: RawVNode<typeof this>): Promise<void> {
         if (dbObject._labels.length !== 3) {
             throw new Error(
                 `Every EntryFeatureData VNode should have exactly three labels: VNode, EntryFeature, and _______Feature (a specific feature type)`,

--- a/backend/neolace/core/entry/features/Files/FilesFeatureEnabled.ts
+++ b/backend/neolace/core/entry/features/Files/FilesFeatureEnabled.ts
@@ -1,4 +1,4 @@
-import { C, RawVNode, VirtualPropType, VNodeType, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
+import { C, VirtualPropType, VNodeType } from "neolace/deps/vertex-framework.ts";
 import { EntryType } from "neolace/core/schema/EntryType.ts";
 import { EnabledFeature } from "neolace/core/entry/features/EnabledFeature.ts";
 
@@ -28,7 +28,7 @@ export class FilesFeatureEnabled extends EnabledFeature {
 
     static derivedProperties = this.hasDerivedProperties({});
 
-    static async validate(_dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(): Promise<void> {
         // No specific validation
     }
 }

--- a/backend/neolace/core/entry/features/HeroImage/HeroImageFeatureEnabled.ts
+++ b/backend/neolace/core/entry/features/HeroImage/HeroImageFeatureEnabled.ts
@@ -1,4 +1,4 @@
-import { C, Field, RawVNode, VirtualPropType, VNodeType, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
+import { C, Field, VirtualPropType, VNodeType } from "neolace/deps/vertex-framework.ts";
 import { EntryType } from "neolace/core/schema/EntryType.ts";
 import { EnabledFeature } from "neolace/core/entry/features/EnabledFeature.ts";
 
@@ -28,7 +28,7 @@ export class HeroImageFeatureEnabled extends EnabledFeature {
 
     static derivedProperties = this.hasDerivedProperties({});
 
-    static async validate(_dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(): Promise<void> {
         // No specific validation
     }
 }

--- a/backend/neolace/core/entry/features/Image/ImageFeatureEnabled.ts
+++ b/backend/neolace/core/entry/features/Image/ImageFeatureEnabled.ts
@@ -1,4 +1,4 @@
-import { C, RawVNode, VirtualPropType, VNodeType, WrappedTransaction } from "neolace/deps/vertex-framework.ts";
+import { C, VirtualPropType, VNodeType } from "neolace/deps/vertex-framework.ts";
 import { EntryType } from "neolace/core/schema/EntryType.ts";
 import { EnabledFeature } from "neolace/core/entry/features/EnabledFeature.ts";
 
@@ -26,7 +26,7 @@ export class ImageFeatureEnabled extends EnabledFeature {
 
     static derivedProperties = this.hasDerivedProperties({});
 
-    static async validate(_dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(): Promise<void> {
         // No specific validation
     }
 }

--- a/backend/neolace/core/objstore/DataFile.ts
+++ b/backend/neolace/core/objstore/DataFile.ts
@@ -1,14 +1,5 @@
 import * as check from "neolace/deps/computed-types.ts";
-import {
-    C,
-    defineAction,
-    DerivedProperty,
-    Field,
-    RawVNode,
-    VNID,
-    VNodeType,
-    WrappedTransaction,
-} from "neolace/deps/vertex-framework.ts";
+import { C, defineAction, DerivedProperty, Field, RawVNode, VNID, VNodeType } from "neolace/deps/vertex-framework.ts";
 import { config } from "neolace/app/config.ts";
 import { FileMetadata, FileMetadataSchema } from "./detect-metadata.ts";
 import { getSignedDownloadUrl } from "./objstore.ts";
@@ -49,7 +40,7 @@ export class DataFile extends VNodeType {
         publicUrl,
     });
 
-    static async validate(dbObject: RawVNode<typeof this>, _tx: WrappedTransaction): Promise<void> {
+    static async validate(dbObject: RawVNode<typeof this>): Promise<void> {
         if (dbObject.metadata) {
             FileMetadataSchema(dbObject.metadata); // Validate the metadata against the schema
         }

--- a/backend/neolace/deps/vertex-framework.ts
+++ b/backend/neolace/deps/vertex-framework.ts
@@ -1,3 +1,3 @@
 // For local dev:
 // export * from "../../../../vertex-framework/vertex/index.ts";
-export * from "https://raw.githubusercontent.com/neolace-dev/vertex-framework/49d7d76c304ef10cc85cd64ce51e280653552b35/vertex/index.ts";
+export * from "https://raw.githubusercontent.com/neolace-dev/vertex-framework/6210f4657247deecfa4cbeea60732e312c7a0e16/vertex/index.ts";


### PR DESCRIPTION
Matching a corresponding refactor of Vertex Framework ( https://github.com/neolace-dev/vertex-framework/pull/25 ), this PR dramatically improves the speed of bulk imports by optimizing the "extended validation" of newly created VNodes.

Before, the validation process was like this:
1. Validate a single updated `PropertyFact`
    -> do 3 queries on the database to validate this PropertyFact, each one dependent on the previous one
2. Validate another updated `PropertyFact`
    -> do 3 queries on the database to validate this PropertyFact, each one dependent on the previous one
...

Now, it's like this:
1. Validate ALL updated `PropertyFact` VNodes from the current action
   -> do 1 query that validates all of them at once
   -> if any were relationship properties, do 1 additional query that validates all the relationships at once.



So if 80 PropertyFacts were modified in a given bulk import action, this reduces the number of sequential queries from ~ 240 to ~2.