### PR TITLE
fix: Revalidate the home page every minute

### DIFF
--- a/frontend/pages/site/[siteHost]/index.tsx
+++ b/frontend/pages/site/[siteHost]/index.tsx
@@ -77,5 +77,6 @@ export const getStaticProps: GetStaticProps<PageProps, PageUrlQuery> = async (co
             homepageContent: homePage.homePageContent,
             refCache: homePage.referenceCache,
         },
+        revalidate: 60, // Re-create the cached page after 60 seconds, but still show the cached one while doing so.
     };
 };


### PR DESCRIPTION
Currently once you deploy the frontend, each site's homepage is frozen at whatever version it has when it is first viewed. This should fix it so it can be updated over time.