### PR TITLE
fix(backend): permissions issue with new AllEntriesFilterableValue

### DIFF
--- a/backend/neolace/api/site/[siteKey]/home.ts
+++ b/backend/neolace/api/site/[siteKey]/home.ts
@@ -19,6 +19,7 @@ export class SiteHomeResource extends NeolaceHttpResource {
         const refCache = new ReferenceCache({ siteId });
         refCache.extractMarkdownReferences(siteData.homePageContent ?? "", { currentEntryId: undefined });
 
+        // TODO: Retrieve the user-specific version of this content? Currently it's always anonymous
         return {
             homePageContent: siteData.homePageContent ?? "",
             referenceCache: await graph.read((tx) => refCache.getData(new LookupContext({ tx, siteId }))),

--- a/backend/neolace/core/permissions/grant.test.ts
+++ b/backend/neolace/core/permissions/grant.test.ts
@@ -166,7 +166,7 @@ group("Grant conditions", () => {
         for (const [key, value] of Object.entries(predicate.params)) {
             queryString = queryString.replaceAll(`$${key}`, value as string);
         }
-        assertEquals(queryString, "(conditionA) OR (conditionB)");
+        assertEquals(queryString, "(conditionA OR conditionB)");
     });
 
     test("OneOfCondition - equals()", () => {
@@ -261,7 +261,7 @@ group("Grant conditions", () => {
         for (const [key, value] of Object.entries(predicate.params)) {
             queryString = queryString.replaceAll(`$${key}`, value as string);
         }
-        assertEquals(queryString, "(conditionA) AND (conditionB)");
+        assertEquals(queryString, "(conditionA AND conditionB)");
     });
 
     test("AllOfCondition - equals()", () => {

--- a/backend/neolace/core/permissions/grant.ts
+++ b/backend/neolace/core/permissions/grant.ts
@@ -380,11 +380,11 @@ export class OneOfCondition extends BooleanCondition {
     }
 
     public override asCypherPredicate(context: CypherPredicateContext): CypherQuery {
-        let p = C`(${this.innerConditions[0].asCypherPredicate(context)})`;
+        let p = C`(${this.innerConditions[0].asCypherPredicate(context)}`;
         for (let i = 1; i < this.innerConditions.length; i++) {
-            p = C`${p} OR (${this.innerConditions[i].asCypherPredicate(context)})`;
+            p = C`${p} OR ${this.innerConditions[i].asCypherPredicate(context)}`;
         }
-        return p;
+        return C`${p})`;
     }
 
     public override simplify(): GrantCondition {
@@ -459,11 +459,11 @@ export class AllOfCondition extends BooleanCondition {
     }
 
     public override asCypherPredicate(context: CypherPredicateContext): CypherQuery {
-        let p = C`(${this.innerConditions[0].asCypherPredicate(context)})`;
+        let p = C`(${this.innerConditions[0].asCypherPredicate(context)}`;
         for (let i = 1; i < this.innerConditions.length; i++) {
-            p = C`${p} AND (${this.innerConditions[i].asCypherPredicate(context)})`;
+            p = C`${p} AND ${this.innerConditions[i].asCypherPredicate(context)}`;
         }
-        return p;
+        return C`${p})`;
     }
 
     /**


### PR DESCRIPTION
On the CAMS site, the wrong entries were being listed on the home page due to cypher boolean operators for permissions checks being combined without proper parentheses.

It was checking `!A or A and C` which is actually`!A or (A and C)`
instead of `(!A or A) and C`

so instead of filtering to just show C entries, it was showing all entries.