### PR TITLE
Better workflow for proposing schema edits

### DIFF
--- a/frontend/components/widgets/Table.tsx
+++ b/frontend/components/widgets/Table.tsx
@@ -18,7 +18,7 @@ export const Table: React.FunctionComponent<Props> = (props: Props) => {
             <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
                 <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
                     <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
-                        <table className="min-w-full divide-y divide-gray-300">
+                        <table className="min-w-full max-w-full divide-y divide-gray-300">
                             <thead className="bg-gray-50">
                                 <tr>
                                     {props.headings.map((h, idx) =>
@@ -52,7 +52,7 @@ export const TableRow: React.FunctionComponent<TableRowProps> = (props: TableRow
     return (
         // first 
         // last sm:pr-6
-        <tr className="[&>td]:relative [&>td]:whitespace-nowrap [&>td]:py-4 [&>td]:pl-3 [&>td]:pr-4 [&>td]:text-sm [&>td]:font-medium [&>td:first-child]:sm:pl-6 [&>td:last-child]:sm:pr-6">
+        <tr className="[&>td]:relative [&>td]:py-4 [&>td]:pl-3 [&>td]:pr-4 [&>td]:text-sm [&>td]:font-medium [&>td:first-child]:sm:pl-6 [&>td:last-child]:sm:pr-6">
             {props.children}
         </tr>
     );

--- a/frontend/lib/api-data/DraftData.ts
+++ b/frontend/lib/api-data/DraftData.ts
@@ -82,7 +82,7 @@ export function useDraft(
      */
     context: { draftContext?: DraftContextData } = {},
 ): SDK.AnyEdit[] {
-    const [draft, unsavedEdits] = useDraft();
+    const [draft, unsavedEdits] = useDraft(context);
 
     const result: SDK.AnyEdit[] = React.useMemo(() => {
         if (draft && draft.status === SDK.DraftStatus.Open) {

--- a/frontend/pages/site/[siteHost]/draft/[draftNum]/schema/edit.tsx
+++ b/frontend/pages/site/[siteHost]/draft/[draftNum]/schema/edit.tsx
@@ -1,0 +1,359 @@
+import React from "react";
+import { NextPage } from "next";
+import { FormattedMessage, useIntl } from "react-intl";
+import {
+    SDK,
+    client,
+    NEW,
+    useSiteData,
+    useSchema,
+    DraftContextData,
+    useDraft,
+    DraftContext,
+    UserStatus,
+    useUser,
+} from "lib/sdk";
+
+import { SitePage } from "components/SitePage";
+import FourOhFour from "pages/404";
+import { ErrorMessage } from "components/widgets/ErrorMessage";
+import { Breadcrumb, Breadcrumbs } from "components/widgets/Breadcrumbs";
+import { useRouter } from "next/router";
+import { ParsedUrlQuery } from "querystring";
+import { Control, Form } from "components/form-input/Form";
+import { Button, ToolbarButton } from "components/widgets/Button";
+import { Tab, TabBarRouter } from "components/widgets/Tabs";
+import { defineMessage } from "components/utils/i18n";
+import { EditDescription } from "components/widgets/EditDescription";
+import { TextInput } from "components/form-input/TextInput";
+import { Table, TableRow } from "components/widgets/Table";
+import { Icon } from "components/widgets/Icon";
+import { EntryTypeModal } from "components/schema-editor/EntryTypeModal";
+import { EditSchemaPropertiesModal } from "components/schema-editor/EditSchemaPropertiesModal";
+
+interface PageUrlQuery extends ParsedUrlQuery {
+    siteHost: string;
+    draftNum: string;
+}
+
+const emptyArray: SDK.AnyEdit[] = []; // Declare this out here so it doesn't change on every render of this page
+const NEW_ENTRY_TYPE = Symbol("newET");
+
+const DraftSchemaEditPage: NextPage = function (_props) {
+    const intl = useIntl();
+    // Look up the Neolace site by domain:
+    const { site, siteError } = useSiteData();
+    const router = useRouter();
+    const user = useUser();
+    const query = router.query as PageUrlQuery;
+    const draftNum = query.draftNum === "_" ? "_" : parseInt(query.draftNum);
+
+    // Any edits that the user has made on this page now, but hasn't yet saved to a draft:
+    const [unsavedEdits, setUnsavedEdits] = React.useState<SDK.AnyEdit[]>([]);
+    const addUnsavedEdit = React.useCallback((newEdit: SDK.AnyEdit) => {
+        setUnsavedEdits((existingEdits) => SDK.consolidateEdits([...existingEdits, newEdit]));
+    }, []);
+
+    const draftContext: DraftContextData = {
+        draftNum,
+        unsavedEdits,
+    };
+    const [draft, _, draftError] = useDraft({draftContext});
+
+    // This is the entry after all edits have been applied
+    const [schema, schemaError] = useSchema({draftContext});
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Managing the draft (all edits are part of a draft)
+
+    // If we'll be creating a new draft when the user saves these changes, this is the title for that new draft:
+    const [newDraftTitle, setNewDraftTitle] = React.useState("");
+    const defaultDraftTitle = intl.formatMessage({id: '2smKb9', defaultMessage: `Edited Schema` });
+    const newDraftTitleChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+        setNewDraftTitle(event.target.value);
+    }, []);
+    const [isSaving, setIsSaving] = React.useState(false);
+    const saveChangesToDraft = React.useCallback(async (applyImmediately = false) => {
+        if (draftError) {
+            // This shouldn't happen because if there's a draft error, the save button won't be shown. But just in case:
+            return alert("Inconsistent state: cannot save changes to a draft with errors.");
+        }
+        setIsSaving(true);
+        if (draftNum === NEW) {
+            // We're creating a new draft:
+            await client.createDraft({
+                title: newDraftTitle.trim() || defaultDraftTitle,
+                description: "",
+                edits: unsavedEdits,
+            }, { siteKey: site.key }).then(
+                (newDraft) => { // If successful:
+                    if (applyImmediately) {
+                        client.acceptDraft(newDraft.num, {siteKey: site.key}).then(() => {
+                            // The draft has been accepted immediately:
+                            router.push(`/draft?status=accepted`);
+                        }, (applyError) => {
+                            console.error(applyError);
+                            alert(
+                                intl.formatMessage({
+                                    id: "Y3wO1p",
+                                    defaultMessage: `Failed to apply changes: {error}`,
+                                }, { error: String((applyError instanceof Error ? applyError?.message : undefined) ?? applyError) }),
+                            );
+                            // The draft failed to apply. Go to the draft page.
+                            router.push(`/draft/${newDraft.num}`);
+                        });
+                    } else {
+                        router.push(`/draft/${newDraft.num}`);
+                    }
+                },
+                (error) => {
+                    setIsSaving(false);
+                    console.error(error);
+                    alert(
+                        intl.formatMessage({
+                            id: "uAFusW",
+                            defaultMessage: `Failed to save draft: {error}`,
+                        }, { error: String(error?.message ?? error) }),
+                    );
+                },
+            );
+        } else {
+            try {
+                for (const edit of unsavedEdits) {
+                    await client.addEditToDraft(edit, {draftNum, siteKey: site.key});
+                }
+                setIsSaving(false);
+                router.push(`/draft/${draftNum}`);
+            } catch (error) {
+                setIsSaving(false);
+                console.error(error);
+                alert(
+                    intl.formatMessage({
+                        id: "uAFusW",
+                        defaultMessage: `Failed to save draft: {error}`,
+                    }, { error: String((error instanceof Error ? error?.message : undefined) ?? error) }),
+                );
+            }
+        }
+    }, [draftError, draftNum, newDraftTitle, defaultDraftTitle, unsavedEdits, site.key, router, intl]);
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Editing an entry type:
+
+    // Show a modal (popup) that allows the user to create a new entry type
+    const [showingEditEntryTypeModalWithKey, editEntryTypeWithKey] = React.useState(undefined as string|typeof NEW_ENTRY_TYPE|undefined);
+    const showNewEntryTypeModal = React.useCallback(() => { editEntryTypeWithKey(NEW_ENTRY_TYPE); }, []);
+    const cancelEditEntryTypeModal = React.useCallback(() => { editEntryTypeWithKey(undefined); }, []);
+
+    const doneEditingEntryType = React.useCallback((editedEntryTypeKey: string, edits: SDK.AnySchemaEdit[]) => {
+        for (const edit of edits) { addUnsavedEdit(edit); }
+        editEntryTypeWithKey(undefined); // close the modal
+    }, [addUnsavedEdit]);
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Editing properties
+
+    const [showingPropertiesSchemaEditor, setShowingPropertiesSchemaEditor] = React.useState(false);
+    const showPropertiesSchemaEditor = React.useCallback(() => setShowingPropertiesSchemaEditor(true), []);
+    const cancelPropertiesSchemaEditor = React.useCallback(() => setShowingPropertiesSchemaEditor(false), []);
+    const doneEditingSchemaProperties = React.useCallback((edits: SDK.AnySchemaEdit[]) => {
+        // Create the new entry type, by adding the edits to unsavedEdits:
+        for (const edit of edits) { addUnsavedEdit(edit); }
+        setShowingPropertiesSchemaEditor(false);
+    }, [addUnsavedEdit]);
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    if (siteError instanceof SDK.NotFound) {
+        return <FourOhFour />;
+    } else if (siteError) {
+        return <ErrorMessage>{String(siteError)}</ErrorMessage>;
+    }
+
+    let content: JSX.Element;
+    // Are there any other errors?
+    if (user.status === UserStatus.Anonymous) {
+        content = <ErrorMessage>You need to log in before you can edit or create entries.</ErrorMessage>;
+    } else if (draftError) {
+        content = <ErrorMessage>Draft error: {String(draftError)}</ErrorMessage>;
+    } else if (schemaError) {
+        content = <ErrorMessage>Schema error: {String(schemaError)}</ErrorMessage>;
+    } else if (draft?.status === SDK.DraftStatus.Accepted || draft?.status === SDK.DraftStatus.Cancelled) {
+        content = <ErrorMessage>This draft is no longer editable.</ErrorMessage>;
+    } else {
+        content = (
+            <DraftContext.Provider value={draftContext}>
+                <Breadcrumbs>
+                    <Breadcrumb href={`/`}>{site.name}</Breadcrumb>
+                    <Breadcrumb href={`/draft/`}>
+                        <FormattedMessage id="2atspc" defaultMessage="Drafts" />
+                    </Breadcrumb>
+                    <Breadcrumb href={draft ? `/draft/${draft.num}` : undefined}>
+                        {draft ? draft.title : <FormattedMessage id="CaAyve" defaultMessage="New Draft" />}
+                    </Breadcrumb>
+                    <Breadcrumb>
+                        <FormattedMessage defaultMessage="Edit schema" id="gZGnMw" />
+                    </Breadcrumb>
+                </Breadcrumbs>
+
+                <h1><FormattedMessage id="oYlGfx" defaultMessage="Edit Schema" /></h1>
+
+                <TabBarRouter>
+                    <Tab
+                        id="entry-types"
+                        icon="info-circle"
+                        name={defineMessage({ defaultMessage: "Entry Types", id: 'xrP950' })}
+                    >
+                        <Table headings={[
+                            {heading: defineMessage({defaultMessage: "Entry Type", id: 'fVyv5L'})},
+                            {heading: defineMessage({defaultMessage: "Description", id: 'Q8Qw5B'})},
+                            {heading: defineMessage({defaultMessage: "Actions", id: 'wL7VAE'}), right: true},
+                        ]}>
+                            {
+                                // Show a row for each file.
+                                Object.values(schema?.entryTypes ?? {}).map((entryType) => <TableRow key={entryType.key}>
+                                    <td className="min-w-[11em]">
+                                        <strong className="align-middle">
+                                            <span
+                                                style={{color: SDK.getEntryTypeColor(entryType).darkerBackgroundColor}}
+                                                className="text-xs inline-block pr-1"
+                                            >
+                                                <Icon icon="square-fill"/>
+                                            </span>
+                                            {entryType.name}
+                                        </strong><br />
+                                        <code className="ml-4 whitespace-nowrap">{entryType.key}</code>
+                                    </td>
+                                    <td>{entryType.description}</td>
+                                    <td className="text-right">
+                                        <ToolbarButton
+                                            icon="three-dots" tooltip={defineMessage({defaultMessage: "Edit", id: 'wEQDC6'})}
+                                            onClick={() => editEntryTypeWithKey(entryType.key)}
+                                        />
+                                    </td>
+                                </TableRow>)
+                            }
+                            <TableRow>
+                                <td colSpan={3}>
+                                    <Button onClick={showNewEntryTypeModal}>
+                                        <Icon icon="plus-lg"/>
+                                        <FormattedMessage defaultMessage="Add new entry type" id="r99oE2" />
+                                    </Button>
+                                </td>
+                            </TableRow>
+                        </Table>
+                    </Tab>
+                    <Tab
+                        id="properties"
+                        icon="diamond-fill"
+                        name={defineMessage({ defaultMessage: "Properties", id: "aI80kg" })}
+                    >
+                        <Button onClick={showPropertiesSchemaEditor}>
+                            <FormattedMessage defaultMessage="Edit properties..." id="f2/zyG" />
+                        </Button>
+                    </Tab>
+                    <Tab
+                        id="save"
+                        icon="check-circle-fill"
+                        name={defineMessage({ defaultMessage: "Save Changes", id: "3VI9mt" })}
+                        badge={unsavedEdits.length ? unsavedEdits.length.toString() : undefined}
+                    >
+                        <h3><FormattedMessage id="dgqhUM" defaultMessage="Changes" /></h3>
+                            {unsavedEdits.length > 0
+                                ? (
+                                    <ul>
+                                        {unsavedEdits.map((e, idx) => (
+                                            <li key={idx}>
+                                                <EditDescription edit={e} />
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )
+                                : (
+                                    <p>
+                                        <FormattedMessage
+                                            id="by5rU2"
+                                            defaultMessage="You haven't made any changes yet. Make some changes using the other tabs and you'll be able to save the changes here."
+                                        />
+                                    </p>
+                                )
+                            }
+
+                        <h3><FormattedMessage id="H/DODr" defaultMessage="Save these changes" /></h3>
+                        {draft
+                            ? (
+                                <Button
+                                    icon="file-earmark-diff"
+                                    disabled={unsavedEdits.length === 0 || isSaving}
+                                    onClick={() => saveChangesToDraft()}
+                                >
+                                    <FormattedMessage
+                                        id="S/a7rH"
+                                        defaultMessage='Save these changes (to draft "{title}")'
+                                        values={{ title: draft.title }}
+                                    />
+                                </Button>
+                            )
+                            : (
+                                <Form>
+                                    <Control
+                                        id="draft-desc"
+                                        label={defineMessage({
+                                            id: "uRwjl1",
+                                            defaultMessage: "Provide a brief description of what you changed (optional):",
+                                        })}
+                                    >
+                                        <TextInput value={newDraftTitle} onChange={newDraftTitleChange} placeholder={defaultDraftTitle} />
+                                    </Control>
+                                    <Button
+                                        icon="file-earmark-diff"
+                                        disabled={unsavedEdits.length === 0 || isSaving}
+                                        onClick={() => saveChangesToDraft()}
+                                        bold={true}
+                                    >
+                                        <FormattedMessage
+                                            id="TpheOq"
+                                            defaultMessage="Save these changes (as draft)"
+                                        />
+                                    </Button>
+                                    <Button
+                                        disabled={unsavedEdits.length === 0 || isSaving}
+                                        onClick={() => saveChangesToDraft(true)}
+                                    >
+                                        <FormattedMessage
+                                            id="zUjePC"
+                                            defaultMessage="Save immediately"
+                                        />
+                                    </Button>
+                                </Form>
+                            )}
+                    </Tab>
+                </TabBarRouter>
+
+                {
+                    showingEditEntryTypeModalWithKey ?
+                        <EntryTypeModal
+                            existingEntryTypeKey={showingEditEntryTypeModalWithKey === NEW_ENTRY_TYPE ? undefined : showingEditEntryTypeModalWithKey}
+                            onSaveChanges={doneEditingEntryType}
+                            onCancel={cancelEditEntryTypeModal}
+                        />
+                    : null
+                }
+                {showingPropertiesSchemaEditor ?
+                    <EditSchemaPropertiesModal onSaveChanges={doneEditingSchemaProperties} onCancel={cancelPropertiesSchemaEditor} />
+                : null}
+            </DraftContext.Provider>
+        );
+    }
+
+    return (
+        <SitePage
+            title={intl.formatMessage({ id: 'oYlGfx', defaultMessage: `Edit Schema` })}
+            leftNavTopSlot={[]}
+        >
+            {content}
+        </SitePage>
+    );
+};
+
+export default DraftSchemaEditPage;

--- a/frontend/pages/site/[siteHost]/draft/index.tsx
+++ b/frontend/pages/site/[siteHost]/draft/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { NextPage } from "next";
 import { FormattedMessage, FormattedRelativeTime, useIntl } from "react-intl";
-import { SDK, client, useSiteData, useUser } from "lib/sdk";
+import { SDK, client, useSiteData, useUser, usePermission, UserStatus } from "lib/sdk";
 
 import { SitePage } from "components/SitePage";
 import { Breadcrumb, Breadcrumbs } from "components/widgets/Breadcrumbs";
@@ -16,8 +16,12 @@ const DraftDetailsPage: NextPage = function (_props) {
     const intl = useIntl();
     // Look up the Neolace site by domain:
     const { site } = useSiteData();
+    const user = useUser();
 
     const title = intl.formatMessage({ id: "2atspc", defaultMessage: `Drafts` });
+
+    const canEditSchema = usePermission(SDK.CorePerm.proposeEditToSchema);
+    const canCreateEntries = usePermission(SDK.CorePerm.proposeNewEntry);
 
     return (
         <SitePage title={title} leftNavTopSlot={[]}>
@@ -41,6 +45,30 @@ const DraftDetailsPage: NextPage = function (_props) {
                     <ListOfDrafts status={SDK.DraftStatus.Cancelled} />
                 </Tab>
             </TabBarRouter>
+
+            <h2><FormattedMessage defaultMessage="Create a new draft" id="HTzod6" /></h2>
+            {
+                canCreateEntries ?
+                    <FormattedMessage
+                        defaultMessage="You can open a new draft by <link>creating a new entry</link>, or by browsing to any existing entry and clicking &quot;Edit&quot;."
+                        id="6ZlReH"
+                        values={{link: (str) => <Link href="/draft/_/entry/_/edit">{str}</Link> }}
+                    />
+                : user.status === UserStatus.LoggedIn ?
+                    <FormattedMessage defaultMessage="You don't have permission to create a new entry, but you may have permission to propose edits to some existing entries." id="6RKiUV" />
+                :
+                    <FormattedMessage defaultMessage="Log in to create a draft." id="nWea5q" />
+            }
+            {" "}
+            {
+                canEditSchema ?
+                    <FormattedMessage
+                        defaultMessage="You can also <link>edit the schema</link>, which will open a new draft with your proposed changes."
+                        id="iO9KyN"
+                        values={{link: (str) => <Link href="/draft/_/schema/edit">{str}</Link> }}
+                    />
+                : null
+            }
         </SitePage>
     );
 };
@@ -65,7 +93,7 @@ const ListOfDrafts: React.FunctionComponent<{ status: SDK.DraftStatus }> = ({ st
     }
 
     return (
-        <ol>
+        <ol className="min-h-[300px]">
             {(data?.values || []).map((draft) => (
                 <li key={draft.num}>
                     <Link href={`/draft/${draft.num}`}>


### PR DESCRIPTION
Until now, it was possible to edit the schema while also editing an existing entry or new entry, but it was not possible to create a draft that had only schema edits, without starting from editing an entry or creating a new entry.

This PR implements a workflow for proposing schema edits, without necessarily any content edits.

You start from the drafts page:
![edit-schema](https://user-images.githubusercontent.com/945577/224894359-d97728a8-0219-4cc1-864f-16f16bf01cbd.png)

And then you'll see this schema editor:
![edit-schema2](https://user-images.githubusercontent.com/945577/224894381-20444f41-e17b-4038-a9a6-c4dc72676313.png)

Later, we'll remove or simplify this workflow so that schema edits can be proposed from the "view schema" page; since we don't have such a page right now, this was the simplest approach.