### PR TITLE
fix(backend): Expose edit errors to the requesting client

### DIFF
--- a/backend/neolace/core/entry/Entry.ts
+++ b/backend/neolace/core/entry/Entry.ts
@@ -2,6 +2,7 @@ import * as check from "neolace/deps/computed-types.ts";
 import {
     C,
     Field,
+    FieldValidationError,
     ValidationError,
     VirtualPropType,
     VNID,
@@ -99,7 +100,7 @@ export class Entry extends VNodeType {
             // Check the keyPrefix:
             const keyPrefix = entryData.type?.keyPrefix;
             if (keyPrefix && !entryData.key.startsWith(keyPrefix)) {
-                throw new ValidationError(`Invalid key; expected it to start with ${keyPrefix}`);
+                throw new FieldValidationError("key", `Invalid key; expected it to start with ${keyPrefix}`);
             }
         }
 

--- a/backend/neolace/plugins/api.ts
+++ b/backend/neolace/plugins/api.ts
@@ -1,6 +1,8 @@
 /** Public API that plugins can use */
 
 export * as log from "std/log/mod.ts";
+export * as SDK from "neolace/deps/neolace-sdk.ts";
+/** @deprecated */
 export * as api from "neolace/deps/neolace-sdk.ts";
 
 export { config as realmConfig } from "neolace/app/config.ts";


### PR DESCRIPTION
Some common edit errors were resulting in 500 Internal Server Error when they should have been 400 errors with details of what was wrong. This PR makes some of those fixes.