### PR TITLE
Partial Date Values (Lookup Value)

### DIFF
--- a/backend/neolace/core/entry/reference-cache.ts
+++ b/backend/neolace/core/entry/reference-cache.ts
@@ -261,6 +261,7 @@ export class ReferenceCache {
             case "Range":
             case "String":
             case "Date":
+            case "DatePartial":
             case "Null":
             case "Error":
             case "File":

--- a/backend/neolace/core/lookup/expressions/functions/date.test.ts
+++ b/backend/neolace/core/lookup/expressions/functions/date.test.ts
@@ -7,7 +7,7 @@ import {
     test,
     TestLookupContext,
 } from "neolace/lib/tests.ts";
-import { DateValue, StringValue } from "../../values.ts";
+import { DatePartialValue, DateValue, StringValue } from "../../values.ts";
 import { DateExpression } from "./date.ts";
 import { LiteralExpression } from "../literal-expr.ts";
 import { LookupEvaluationError } from "../../errors.ts";
@@ -16,6 +16,15 @@ group("date.ts", () => {
     const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
     const siteId = defaultData.site.id;
     const context = new TestLookupContext({ siteId });
+
+    async function checkInvalidStr(dateStr: string, errorStr?: string) {
+        const expr = new DateExpression(new LiteralExpression(new StringValue(dateStr)));
+        await assertRejects(
+            () => context.evaluateExpr(expr),
+            LookupEvaluationError,
+            errorStr ?? "Date values should be in the format YYYY-MM-DD (or YYYY, YYYY-MM, MM-DD, or MM).",
+        );
+    }
 
     test(`toString()`, async () => {
         const expr = new DateExpression(new LiteralExpression(new StringValue("2020-01-10")));
@@ -44,20 +53,73 @@ group("date.ts", () => {
     });
 
     test(`It rejects invalid dates`, async () => {
-        async function checkString(dateStr: string, errorStr: string) {
-            const expr = new DateExpression(new LiteralExpression(new StringValue(dateStr)));
-            await assertRejects(
-                () => context.evaluateExpr(expr),
-                LookupEvaluationError,
-                errorStr,
-            );
-        }
-
         // These are all invalid dates:
-        await checkString("foobar", "Date values should be in the format YYYY-MM-DD.");
-        await checkString("", "Date values should be in the format YYYY-MM-DD.");
-        await checkString("1234-56-78", "1234-56-78 is not a valid date.");
-        await checkString("2020-02-45", "2020-02-45 is not a valid date.");
-        await checkString("2070-02-29", "Invalid date."); // Not a leap year
+        await checkInvalidStr("foobar");
+        await checkInvalidStr("NNNN-NN-NN");
+        await checkInvalidStr("");
+        await checkInvalidStr("123");
+        await checkInvalidStr("1234-56-78", "1234-56-78 is not a valid date.");
+        await checkInvalidStr("2020-02-45", "2020-02-45 is not a valid date.");
+        await checkInvalidStr("2070-02-29", "Invalid date."); // Not a leap year
+    });
+
+    async function checkPartialString(
+        dateStr: string,
+        expected: { year?: number; month?: number; day?: number },
+        expectedIsoStr?: string,
+    ) {
+        const expr = new DateExpression(new LiteralExpression(new StringValue(dateStr)));
+        const value = await context.evaluateExpr(expr);
+        assertInstanceOf(value, DatePartialValue);
+        assertEquals(value, new DatePartialValue(expected));
+        assertEquals(value.asIsoString(), expectedIsoStr ?? dateStr);
+    }
+
+    test(`It can parse partial dates - YYYY format`, async () => {
+        await checkPartialString("2020", { year: 2020 });
+        await checkPartialString("1865", { year: 1865 });
+        await checkPartialString("3000", { year: 3000 });
+        // Invalid:
+        await checkInvalidStr("1000", `Invalid year "1000"; needs to be between 1583 and 9999 CE.`);
+    });
+
+    test(`It can parse partial dates - YYYY-MM format`, async () => {
+        await checkPartialString("2020-01", { year: 2020, month: 1 });
+        await checkPartialString("1999-05", { year: 1999, month: 5 });
+        await checkPartialString("3000-12", { year: 3000, month: 12 });
+    });
+
+    test(`It can parse partial dates with only a month - MM or --MM format`, async () => {
+        await checkPartialString("01", { month: 1 }, "--01"); // This "MM" format is our preferred format.
+        await checkPartialString("05", { month: 5 }, "--05");
+        await checkPartialString("12", { month: 12 }, "--12");
+        await checkPartialString("--01", { month: 1 }); // This format was previously defined by an ISO8601 standard
+        await checkPartialString("--05", { month: 5 });
+        await checkPartialString("--12", { month: 12 });
+        // Invalid:
+        await checkInvalidStr("00", `Invalid month "0"; needs to be between 1 and 12.`);
+        await checkInvalidStr("99", `Invalid month "99"; needs to be between 1 and 12.`);
+        await checkInvalidStr("MM");
+        await checkInvalidStr("NN");
+    });
+
+    test(`It can parse partial dates with a month and a day (MM-DD or --MM-DD)`, async () => {
+        await checkPartialString("01-01", { month: 1, day: 1 }, "--01-01");
+        await checkPartialString("05-31", { month: 5, day: 31 }, "--05-31");
+        await checkPartialString("12-25", { month: 12, day: 25 }, "--12-25");
+        await checkPartialString("02-29", { month: 2, day: 29 }, "--02-29"); // Feb 29 is valid
+        await checkPartialString("--01-01", { month: 1, day: 1 });
+        await checkPartialString("--05-31", { month: 5, day: 31 });
+        await checkPartialString("--12-25", { month: 12, day: 25 });
+        await checkPartialString("--02-29", { month: 2, day: 29 }); // Feb 29 is valid
+        // Invalid:
+        await checkInvalidStr("31-12", `Invalid month "31"; needs to be between 1 and 12.`);
+        await checkInvalidStr("--31-12", `Invalid month "31"; needs to be between 1 and 12.`);
+        await checkInvalidStr("00-12", `Invalid month "0"; needs to be between 1 and 12.`);
+        await checkInvalidStr("--00-12", `Invalid month "0"; needs to be between 1 and 12.`);
+        await checkInvalidStr("06-00", `Invalid day "0"; needs to be between 1 and 30.`);
+        await checkInvalidStr("06-31", `Invalid day "31"; needs to be between 1 and 30.`);
+        await checkInvalidStr("07-32", `Invalid day "32"; needs to be between 1 and 31.`);
+        await checkInvalidStr("02-30", `Invalid day "30"; needs to be between 1 and 29.`);
     });
 });

--- a/backend/neolace/core/lookup/values.ts
+++ b/backend/neolace/core/lookup/values.ts
@@ -11,6 +11,7 @@ export {
 export { AnnotatedValue, MakeAnnotatedEntryValue } from "./values/AnnotatedValue.ts";
 export { BooleanValue } from "./values/BooleanValue.ts";
 export { DateValue } from "./values/DateValue.ts";
+export { DatePartialValue } from "./values/DatePartialValue.ts";
 export { EntryTypeValue } from "./values/EntryTypeValue.ts";
 export { EntryValue } from "./values/EntryValue.ts";
 export { ErrorValue } from "./values/ErrorValue.ts";

--- a/backend/neolace/core/lookup/values/DatePartialValue.ts
+++ b/backend/neolace/core/lookup/values/DatePartialValue.ts
@@ -1,0 +1,106 @@
+import { LookupContext } from "../context.ts";
+import { LookupEvaluationError } from "../errors.ts";
+import { ClassOf, ConcreteValue, LookupValue } from "./base.ts";
+import { DateValue } from "./DateValue.ts";
+
+/**
+ * A value that respresents either a year, a year + month, a month (without year), or a month + day (without year).
+ * It never represents an exact date with year, month, and day - that's DateValue.
+ */
+export class DatePartialValue extends ConcreteValue {
+    /** Year () */
+    readonly year: number | undefined;
+    /** Month (January = 1) */
+    readonly month: number | undefined;
+    /** Day (1-31) */
+    readonly day: number | undefined;
+
+    constructor({ year, month, day }: { year?: bigint | number; month?: bigint | number; day?: bigint | number }) {
+        super();
+        this.year = year === undefined ? undefined : Number(year);
+        this.month = month === undefined ? undefined : Number(month);
+        this.day = day === undefined ? undefined : Number(day);
+        // Validate:
+        if (this.year !== undefined) {
+            if (this.year < 1583 || this.year > 9999) {
+                throw new LookupEvaluationError(`Invalid year "${this.year}"; needs to be between 1583 and 9999 CE.`);
+            }
+            // Month may or may not be defined; either way is valid.
+            if (this.day !== undefined) {
+                throw new LookupEvaluationError("DatePartialValue cannot have both year and day. Use Date instead.");
+            }
+        }
+        if (this.month !== undefined) {
+            if (this.month < 1 || this.month > 12) {
+                throw new LookupEvaluationError(`Invalid month "${this.month}"; needs to be between 1 and 12.`);
+            }
+        }
+        if (this.day !== undefined) {
+            if (this.month === undefined) {
+                throw new LookupEvaluationError(`Cannot specify a day without a month.`);
+            }
+            const maxDay = this.month == 2 ? 29 : [4, 6, 9, 11].includes(this.month) ? 30 : 31;
+            if (this.day < 1 || this.day > maxDay) {
+                throw new LookupEvaluationError(`Invalid day "${this.day}"; needs to be between 1 and ${maxDay}.`);
+            }
+        }
+    }
+
+    /**
+     * Return this value as a string, in Neolace Lookup Expression format.
+     * This string should parse to an expression that yields the same value.
+     */
+    public override asLiteral(): string {
+        return `date("${this.asIsoString()}")`;
+    }
+
+    /**
+     * Return this partial date as a string in ISO 8601 format.
+     *
+     * Technically, the representations for year+month, month+day, and month alone were only defined/allowed in the
+     * 2000 version of ISO-8601 which has been superseded, but we still use them as there's no newer alternative.
+     */
+    public asIsoString(): string {
+        if (this.year !== undefined) {
+            const yearStr = this.year.toString().padStart(4, "0000");
+            // Return "YYYY" or "YYYY-MM"
+            return this.month === undefined ? yearStr : `${yearStr}-${this.month.toString().padStart(2, "0")}`;
+        }
+        if (this.month === undefined) throw new Error("month unexpectedly missing");
+        if (this.day !== undefined) {
+            // We are returning a month and day, in the format "--MM-DD"
+            return `--${this.month.toString().padStart(2, "0")}-${this.day.toString().padStart(2, "0")}`;
+        }
+        // We are just returning a month, with no year or day.
+        return `--${this.month.toString().padStart(2, "0")}`;
+    }
+
+    protected serialize() {
+        return {
+            type: "DatePartial" as const,
+            year: this.year,
+            month: this.month,
+            day: this.day,
+            value: this.asIsoString(),
+        };
+    }
+
+    protected override doCastTo(_newType: ClassOf<LookupValue>, _context: LookupContext): LookupValue | undefined {
+        // In the future we may support automatically casting to the nearest Date.
+        return undefined;
+    }
+
+    /** For comparison purposes, fill in any missing values to force this to be a specific full YYYY-MM-DD date. */
+    protected forceToDate(): DateValue {
+        return new DateValue(this.year ?? 9999, this.month ?? 1, this.day ?? 1);
+    }
+
+    public override compareTo(otherValue: LookupValue) {
+        if (otherValue instanceof DateValue || otherValue instanceof DatePartialValue) {
+            const asDate: DateValue = this.forceToDate();
+            const otherDate: DateValue = otherValue instanceof DateValue ? otherValue : otherValue.forceToDate();
+            return asDate.compareTo(otherDate);
+        }
+        return super.compareTo(otherValue); // This will throw
+    }
+}

--- a/backend/neolace/core/lookup/values/DateValue.ts
+++ b/backend/neolace/core/lookup/values/DateValue.ts
@@ -1,7 +1,6 @@
 import { LookupContext } from "../context.ts";
 import { LookupEvaluationError } from "../errors.ts";
 import { ClassOf, ConcreteValue, LookupValue } from "./base.ts";
-import { BooleanValue } from "./BooleanValue.ts";
 
 /**
  * A value that respresents a calendar date (no time)
@@ -38,7 +37,6 @@ export class DateValue extends ConcreteValue {
      * This string should parse to an expression that yields the same value.
      */
     public override asLiteral(): string {
-        // An integer literal just looks like a plain integer, e.g. 5
         return `date("${this.asIsoString()}")`;
     }
 
@@ -53,10 +51,7 @@ export class DateValue extends ConcreteValue {
         return { type: "Date" as const, value: this.asIsoString() };
     }
 
-    protected override doCastTo(newType: ClassOf<LookupValue>, _context: LookupContext): LookupValue | undefined {
-        if (newType === BooleanValue) {
-            return new BooleanValue(true);
-        }
+    protected override doCastTo(_newType: ClassOf<LookupValue>, _context: LookupContext): LookupValue | undefined {
         return undefined;
     }
 

--- a/backend/neolace/rest-api/site/[siteKey]/lookup.test.ts
+++ b/backend/neolace/rest-api/site/[siteKey]/lookup.test.ts
@@ -77,7 +77,7 @@ group("lookup.ts", () => {
         assertEquals(result.resultValue, {
             type: "Error",
             errorClass: "LookupEvaluationError",
-            message: "Date values should be in the format YYYY-MM-DD.",
+            message: "Date values should be in the format YYYY-MM-DD (or YYYY, YYYY-MM, MM-DD, or MM).",
         });
     });
 

--- a/frontend/components/widgets/LookupValue.tsx
+++ b/frontend/components/widgets/LookupValue.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { FormattedListParts, FormattedMessage } from "react-intl";
+import { FormattedDate, FormattedListParts, FormattedMessage } from "react-intl";
 
 import { SDK, useRefCache } from "lib/sdk";
 import { Tooltip } from "components/widgets/Tooltip";
@@ -14,7 +14,6 @@ import { EntryValue } from "./EntryValue";
 import { UiPluginsContext } from "../utils/ui-plugins";
 import { Icon } from "./Icon";
 import { LookupQuantityValue } from "./LookupQuantityValue";
-import { LookupExpressionInput } from "components/form-input/LookupExpressionInput";
 import { LookupDemo } from "./LookupDemo";
 
 interface LookupValueProps {
@@ -227,7 +226,38 @@ export const LookupValue: React.FunctionComponent<LookupValueProps> = (props) =>
         case "InlineMarkdownString":
             return <InlineMDT mdt={value.value} context={props.mdtContext} />;
         case "Date":
-            return <>{value.value}</>;
+            return (
+                <FormattedDate
+                    value={new Date(value.value)}
+                    // Use "medium" because it's nice, and fuck the "2/2/2022" default 🤮
+                    dateStyle="medium"
+                    // The timeZone MUST be UTC or the date may appear wrong, depending on the user's actual timzone.
+                    // (The Date constructor's parsing is messy, but passing an ISO8601 date string with no timezone
+                    // should always result in a UTC date object.) Generally I try to avoid ever using Date() objects
+                    // for calendar dates (that don't have times), because it sucks for that, but we can't avoid it
+                    // here because the Intl API requires a Date object.
+                    timeZone="UTC"
+                />
+            );
+        case "DatePartial":
+            const hasYear = value.year !== undefined, hasMonth = value.month !== undefined, hasDay = value.day !== undefined;
+            // With this constructor, the date is in the user's local time so we must NOT use UTC
+            // (see what I mean? This sucks...)
+            const dateValue = new Date(value.year ?? 3000, (value.month ?? 1) - 1, value.day ?? 1);
+            if (hasYear) {
+                if (hasMonth) {
+                    return <FormattedDate value={dateValue} year="numeric" month="long" />
+                } else {
+                    return <FormattedDate value={dateValue} year="numeric" />
+                }
+            } else {
+                // It's either Month and day, or just month:
+                if (hasDay) {
+                    return <FormattedDate value={dateValue} month="long" day="numeric" />
+                } else {
+                    return <FormattedDate value={dateValue} month="long" />
+                }
+            }
         case "Error":
             return (
                 <ErrorMessage>

--- a/neolace-sdk/src/content/lookup-value.ts
+++ b/neolace-sdk/src/content/lookup-value.ts
@@ -151,6 +151,15 @@ export interface DateValue extends LookupValue {
     value: string;
 }
 
+export interface DatePartialValue extends LookupValue {
+    type: "DatePartial";
+    year: number|undefined;
+    month: number|undefined;
+    day: number|undefined;
+    /** ISO 8601 date string (YYYY, YYYY-MM, --MM, --MM-DD) */
+    value: string;
+}
+
 export interface StringValue extends LookupValue {
     type: "String";
     value: string;
@@ -184,6 +193,7 @@ export type AnyLookupValue =
     | QuantityValue
     | RangeValue
     | DateValue
+    | DatePartialValue
     | StringValue
     | InlineMarkdownString
     | NullValue


### PR DESCRIPTION
This PR introduces a new value type to the lookup language - partial date values. A partial date value is either:
- a year (e.g. "2022")
- a year + month ("Jan 2022")
- a month (without year, e.g. "January"), or
- a month + day (without year, e.g. "February 28")
 
A `DatePartialValue` never represents an _exact_ date with year, month, and day - that's `DateValue`.

To make user's lives simple, there is a single `date("...")` function that is used to generate either date values or partial date values, depending on what is passed.

For example:
- `date("2022-05-17")` - produces a `DateValue`
- `date("12-25")` - produces a `DatePartialValue` for "December 25" (no year)
- `date("2023")` - produces a `DatePartialValue` (for the year 2023)