### PR TITLE
Some fixes for our Slate.js editors

### DIFF
--- a/frontend/components/form-input/MDTEditor.tsx
+++ b/frontend/components/form-input/MDTEditor.tsx
@@ -282,7 +282,8 @@ const MarkButton = ({mark, removeMark, ...props}: {
     disabled?: boolean;
 }) => {
     const editor = useSlate();
-    const clickCallback = React.useCallback(() => {
+    const clickCallback = React.useCallback((event: React.MouseEvent) => {
+        event.preventDefault();
         if (isMarkActive(editor, mark)) {
             Editor.removeMark(editor, mark)
         } else {
@@ -297,7 +298,7 @@ const MarkButton = ({mark, removeMark, ...props}: {
     return <ToolbarButton
         icon={props.icon}
         toggled={props.disabled ? false : isMarkActive(editor, mark)}
-        onClick={clickCallback}
+        onMouseDown={clickCallback}
         tooltip={props.tooltip}
         disabled={props.disabled}
     />;

--- a/frontend/components/slate-editor/slate.ts
+++ b/frontend/components/slate-editor/slate.ts
@@ -332,7 +332,7 @@ export function slateDocToStringValue(node: NeolaceSlateElement[], escape: Escap
             }
         } else if (n.type === "paragraph") {
             if (result.length > 0) {
-                result += "\n\n";
+                result += "\n";
             }
             result += slateDocToStringValue(n.children, escape);
         } else if (n.type === "link") {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,9 +26,9 @@
         "react-intl": "6.3.2",
         "react-popper": "2.3.0",
         "scheduler": "0.23.0",
-        "slate": "0.91.4",
+        "slate": "0.88.1",
         "slate-history": "0.86.0",
-        "slate-react": "0.92.0",
+        "slate-react": "0.89.0",
         "swr": "2.1.1"
       },
       "devDependencies": {
@@ -9263,9 +9263,9 @@
       }
     },
     "node_modules/slate": {
-      "version": "0.91.4",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.91.4.tgz",
-      "integrity": "sha512-aUJ3rpjrdi5SbJ5G1Qjr3arytfRkEStTmHjBfWq2A2Q8MybacIzkScSvGJjQkdTk3djCK9C9SEOt39sSeZFwTw==",
+      "version": "0.88.1",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.88.1.tgz",
+      "integrity": "sha512-DEj9RpkNwPfdh3zbE9eGpeOVGWdS8BYQt754S0Lk6IvJXOkYaxza7WEZLZl/vnp7vloMdTe24zccyxywA3XK8g==",
       "dependencies": {
         "immer": "^9.0.6",
         "is-plain-object": "^5.0.0",
@@ -9284,9 +9284,9 @@
       }
     },
     "node_modules/slate-react": {
-      "version": "0.92.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.92.0.tgz",
-      "integrity": "sha512-xEDKu5RKw5f0N95l1UeNQnrB0Pxh4JPjpIZR/BVsMo0ININnLAknR99gLo46bl/Ffql4mr7LeaxQRoXxbFtJOQ==",
+      "version": "0.89.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.89.0.tgz",
+      "integrity": "sha512-ZTR0OwHbFWU9AK2iAUSxqpLK+GZFwTp4RttthDeWFzbF6y0aRAZRAwNNsi21jboZ26/7e8z68y2T9njhjKe/0w==",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "@types/is-hotkey": "^0.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,9 +33,9 @@
     "react-intl": "6.3.2",
     "react-popper": "2.3.0",
     "scheduler": "0.23.0",
-    "slate": "0.91.4",
+    "slate": "0.88.1",
     "slate-history": "0.86.0",
-    "slate-react": "0.92.0",
+    "slate-react": "0.89.0",
     "swr": "2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
* Markdown editor: Clicking on a toolbar button no longer steals focus away from the editor
* Editing the source code of multi-line markdown articles no longer inserts duplicate newlines
* Revert to an old version of Slate to work around bug #229 for now. Still unsure of root cause.