### PR TITLE
fix(backend): The "my permissions" API endpoint was not returning draft-specific permissions

### DIFF
--- a/backend/neolace/rest-api/site/[siteKey]/my-permissions.test.ts
+++ b/backend/neolace/rest-api/site/[siteKey]/my-permissions.test.ts
@@ -7,7 +7,16 @@
  * Change Date: 2027-03-14. On this date, in accordance with the Business Source License, use of this software will be
  * governed by the Mozilla Public License, Version 2.
  */
-import { assert, assertEquals, getClient, group, SDK, setTestIsolation, test } from "neolace/rest-api/tests.ts";
+import {
+    assert,
+    assertEquals,
+    assertRejects,
+    getClient,
+    group,
+    SDK,
+    setTestIsolation,
+    test,
+} from "neolace/rest-api/tests.ts";
 
 group("my-permissions.ts", () => {
     const defaultData = setTestIsolation(setTestIsolation.levels.DEFAULT_NO_ISOLATION);
@@ -67,5 +76,52 @@ group("my-permissions.ts", () => {
         assertEquals(result[SDK.CorePerm.viewSite], { hasPerm: true });
         assertEquals(result[SDK.CorePerm.proposeNewEntry], { hasPerm: true });
         assertEquals(result[SDK.CorePerm.siteAdmin], { hasPerm: true });
+    });
+
+    test("It can get the permissions of a specific draft", async () => {
+        const site1key = defaultData.site.key;
+        const site2key = defaultData.otherSite.key;
+        const adminClient = await getClient(defaultData.users.admin, defaultData.site.key);
+        const regClient = await getClient(defaultData.users.regularUser, defaultData.site.key);
+
+        const draftA = await regClient.createDraft({
+            title: "Draft A",
+            description: "A draft by the regular user on site 1",
+            edits: [{ code: "CreateEntryType", data: { key: "new-et", name: "New ET" } }],
+        }, { siteKey: site1key });
+
+        const draftB = await adminClient.createDraft({
+            title: "Draft B",
+            description: "A draft by the admin user on site 2",
+            edits: [{ code: "CreateEntryType", data: { key: "new-et", name: "New ET" } }],
+        }, { siteKey: site2key });
+
+        // Now if the regular user asks about draft A, they should be able to edit it, because they created it:
+        await regClient.getMyPermissions({ draftNum: draftA.num, siteKey: site1key }).then((result) => {
+            assertEquals(result[SDK.CorePerm.editDraft], { hasPerm: true });
+        });
+        // And if the admin user asks about draft A, they should also be able to edit it since they have superuser powers:
+        await adminClient.getMyPermissions({ draftNum: draftA.num, siteKey: site1key }).then((result) => {
+            assertEquals(result[SDK.CorePerm.editDraft], { hasPerm: true });
+        });
+
+        // But if the regular user asks about draft B, they should NOT be able to edit it, because they didn't create it:
+        await regClient.getMyPermissions({ draftNum: draftB.num, siteKey: site2key }).then((result) => {
+            assertEquals(result[SDK.CorePerm.editDraft], { hasPerm: false });
+        });
+        // And if the admin user asks about draft B, they should be able to edit it since they created it:
+        await adminClient.getMyPermissions({ draftNum: draftB.num, siteKey: site2key }).then((result) => {
+            assertEquals(result[SDK.CorePerm.editDraft], { hasPerm: true });
+        });
+    });
+
+    test("It gives a 404 if asking about permissions of a non-existed draft.", async () => {
+        const client = await getClient(defaultData.users.admin, defaultData.site.key);
+
+        await assertRejects(
+            () => client.getMyPermissions({ draftNum: 12345678 }),
+            SDK.NotFound,
+            "Invalid draft number.",
+        );
     });
 });

--- a/frontend/components/entry-editor/MainEditor.tsx
+++ b/frontend/components/entry-editor/MainEditor.tsx
@@ -148,12 +148,12 @@ export const MainEditor: React.FunctionComponent<Props> = ({ entry, addUnsavedEd
                 />
             </Control>
 
-            {/* Friendly ID */}
+            {/* Key (friendly ID that's used in the URL) */}
             <AutoControl
                 value={entry?.key ?? ""}
                 onChangeFinished={updateEntryKey}
-                id="id"
-                label={defineMessage({ defaultMessage: "ID",  id: 'qlcuNQ' })}
+                id="key"
+                label={defineMessage({ defaultMessage: "Key",  id: 'EcglP9' })}
                 hint={{custom: (intl.formatMessage({
                     id: '6hE8SS',
                     defaultMessage: "Shown in the URL.",
@@ -170,8 +170,8 @@ export const MainEditor: React.FunctionComponent<Props> = ({ entry, addUnsavedEd
                         defaultMessage: "Must be unique.",
                     }) + " " +
                     intl.formatMessage({
-                        id: '05LayV',
-                        defaultMessage: "You cannot re-use an ID that was previously used for a different entry.",
+                        id: 'Q3ZeFn',
+                        defaultMessage: "You cannot re-use a key that was previously used for a different entry.",
                     }))}}
                 isRequired={true}
             >


### PR DESCRIPTION
For some users, they would create a draft but then this button was not enabled to allow them to add more content:

![Screenshot 2023-03-24 at 11 50 37 AM](https://user-images.githubusercontent.com/945577/227614086-0cde335d-606a-4316-8aa0-c6348a7f907d.png)

The bug was related to the transition from `draftId` to `draftNum` some time ago (#186).