### PR TITLE
fix(backend): The sort() function had a bug when used with first()

### DIFF
--- a/backend/neolace/core/lookup/values/AnnotatedValue.ts
+++ b/backend/neolace/core/lookup/values/AnnotatedValue.ts
@@ -67,6 +67,13 @@ export class AnnotatedValue extends ConcreteValue {
         // Then check annotation values:
         return this.annotations[attrName]; // May be undefined
     }
+
+    public override compareTo(otherValue: LookupValue): number {
+        if (otherValue instanceof AnnotatedValue) {
+            return this.value.compareTo(otherValue.value);
+        }
+        return this.value.compareTo(otherValue);
+    }
 }
 
 /** A helper function to create an annotated entry value */


### PR DESCRIPTION
The `sort()` lookup function was generally working but if you did `someValues.sort().first()`, it could result in the wrong value being returned, due to a bug in the sorting logic. I fixed the bug and added more tests to prevent this problem in the future. I also added tests to ensure that the sort is stable, and I updated the logic to make it stable, both forward and in reverse.