### PR TITLE
fix: UpdatePropertyValue wasn't applying properly

### DIFF
--- a/neolace-sdk/src/edit/ContentEdit.ts
+++ b/neolace-sdk/src/edit/ContentEdit.ts
@@ -334,6 +334,7 @@ export const UpdatePropertyFact = ContentEditType({
             if (data.note !== undefined) newFacts[factIndex].note = data.note;
             if (data.rank !== undefined) newFacts[factIndex].rank = data.rank;
             if (data.slot !== undefined) newFacts[factIndex].slot = data.slot;
+            updatedEntry.propertiesRaw[propertyIndex].facts = newFacts;
         }
         return updatedEntry;
     },


### PR DESCRIPTION
With an existing entry, editing a property in a draft then going back to continue editing the entry would show the old property value in the entry editor.