### PR TITLE
Fix PDF downloads on prod site

### DIFF
--- a/backend/neolace/core/objstore/DataFile.ts
+++ b/backend/neolace/core/objstore/DataFile.ts
@@ -11,6 +11,7 @@ import * as check from "neolace/deps/computed-types.ts";
 import { C, defineAction, DerivedProperty, Field, RawVNode, VNID, VNodeType } from "neolace/deps/vertex-framework.ts";
 import { config } from "neolace/app/config.ts";
 import { FileMetadata, FileMetadataSchema } from "./detect-metadata.ts";
+import { getSignedDownloadUrl } from "./objstore.ts";
 
 /**
  * A data file uploaded to Neolace, such as an image, PDF, CSV file, etc.
@@ -99,7 +100,7 @@ export function publicUrl(): DerivedProperty<string> {
             if (config.objStorePublicUrlPrefixForImages && data.contentType.startsWith("image/")) {
                 return `${config.objStorePublicUrlPrefixForImages}/${data.filename}`;
             }
-            return publicUrlForDataFile(data.filename);
+            return `${config.objStorePublicUrlPrefix}/${data.filename}`; // This doesn't use publicUrlForDataFile below because this is synchronous.
         },
     );
 }
@@ -109,12 +110,10 @@ export function publicUrl(): DerivedProperty<string> {
  * @param filename The underlying filename of the DataFile object
  * @param displayFilename The friendly filename that users should see if they save the file
  */
-export function publicUrlForDataFile(filename: string, displayFilename?: string): string {
+export async function publicUrlForDataFile(filename: string, displayFilename?: string): Promise<string> {
     if (!displayFilename) {
         return `${config.objStorePublicUrlPrefix}/${filename}`;
     } else {
-        const queryParam = new URLSearchParams();
-        queryParam.set("response-content-disposition", `inline; filename=${displayFilename}`);
-        return `${config.objStorePublicUrlPrefix}/${filename}?${queryParam.toString()}`;
+        return getSignedDownloadUrl(filename, displayFilename);
     }
 }

--- a/backend/neolace/core/objstore/objstore.ts
+++ b/backend/neolace/core/objstore/objstore.ts
@@ -106,3 +106,12 @@ export async function uploadFileToObjStore(
         metadata,
     };
 }
+
+export async function getSignedDownloadUrl(filename: string, displayFilename?: string): Promise<string> {
+    return objStoreClient.presignedGetObject(
+        filename,
+        displayFilename
+            ? { responseParams: { "response-content-disposition": `inline; filename=${displayFilename}` } }
+            : {},
+    );
+}


### PR DESCRIPTION
This reverts #234 because Backblaze B2 doesn't allow the use of `Content-Disposition` to set the filename unless the request is signed. So we'll use pre-signed URLs for now until/unless we find a better solution.