### PR TITLE
Support bi-directional comparison between DatePartial and Date values

### DIFF
--- a/backend/neolace/core/lookup/values/AnnotatedValue.ts
+++ b/backend/neolace/core/lookup/values/AnnotatedValue.ts
@@ -68,7 +68,7 @@ export class AnnotatedValue extends ConcreteValue {
         return this.annotations[attrName]; // May be undefined
     }
 
-    public override compareTo(otherValue: LookupValue): number {
+    protected override doCompareTo(otherValue: LookupValue): number {
         if (otherValue instanceof AnnotatedValue) {
             return this.value.compareTo(otherValue.value);
         }

--- a/backend/neolace/core/lookup/values/BooleanValue.ts
+++ b/backend/neolace/core/lookup/values/BooleanValue.ts
@@ -33,10 +33,10 @@ export class BooleanValue extends ConcreteValue {
         return { type: "Boolean" as const, value: this.value };
     }
 
-    public override compareTo(otherValue: LookupValue): number {
+    protected override doCompareTo(otherValue: LookupValue): number {
         if (otherValue instanceof BooleanValue) {
             return otherValue.value === this.value ? 0 : (otherValue.value ? -1 : 1);
         }
-        return super.compareTo(otherValue); // This will throw
+        return super.doCompareTo(otherValue); // This will throw
     }
 }

--- a/backend/neolace/core/lookup/values/DatePartialValue.test.ts
+++ b/backend/neolace/core/lookup/values/DatePartialValue.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @copyright (c) MacDonald Thoughtstuff Inc.
+ * @license
+ * Use of this software is governed by the Business Source License included in the LICENSE file and at
+ * www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-03-14. On this date, in accordance with the Business Source License, use of this software will be
+ * governed by the Mozilla Public License, Version 2.
+ */
+import { assertEquals, group, setTestIsolation, test } from "neolace/lib/tests.ts";
+import { DatePartialValue, DateValue, LookupValue } from "../values.ts";
+
+group("DatePartialValue.ts", () => {
+    // These tests don't need any example data.
+    setTestIsolation(setTestIsolation.levels.BLANK_NO_ISOLATION);
+    // Doesn't matter what site ID we use here, since we're not accessing any site data.
+    // const context = new TestLookupContext({ siteId: VNID("_0"), entryId: undefined });
+    const DPV = (args: { year?: number; month?: number; day?: number }) => new DatePartialValue(args);
+
+    test("year only", async () => {
+        const a = DPV({ year: 2010 });
+        assertEquals(a.year, 2010);
+        assertEquals(a.month, undefined);
+        assertEquals(a.day, undefined);
+        assertEquals(a.asIsoString(), "2010");
+        assertEquals(a.toJSON(), { type: "DatePartial", value: "2010", year: 2010 });
+    });
+
+    test("month and day", async () => {
+        const a = DPV({ month: 5, day: 15 });
+        assertEquals(a.year, undefined);
+        assertEquals(a.month, 5);
+        assertEquals(a.day, 15);
+        assertEquals(a.asIsoString(), "--05-15");
+        assertEquals(a.toJSON(), { type: "DatePartial", value: "--05-15", month: 5, day: 15 });
+    });
+
+    test("year and month", async () => {
+        const a = DPV({ month: 10, year: 2029 });
+        assertEquals(a.year, 2029);
+        assertEquals(a.month, 10);
+        assertEquals(a.day, undefined);
+        assertEquals(a.asIsoString(), "2029-10");
+        assertEquals(a.toJSON(), { type: "DatePartial", value: "2029-10", month: 10, year: 2029 });
+    });
+
+    test("month only", async () => {
+        const a = DPV({ month: 1 });
+        assertEquals(a.year, undefined);
+        assertEquals(a.month, 1);
+        assertEquals(a.day, undefined);
+        assertEquals(a.asIsoString(), "--01");
+        assertEquals(a.toJSON(), { type: "DatePartial", value: "--01", month: 1 });
+    });
+
+    group("comparisons", () => {
+        test("Simple comparison of years", async () => {
+            assertEquals(DPV({ year: 2020 }).compareTo(DPV({ year: 2020 })), 0);
+            assertEquals(DPV({ year: 2024 }).compareTo(DPV({ year: 2020 })), 1);
+            assertEquals(DPV({ year: 1995 }).compareTo(DPV({ year: 2020 })), -1);
+        });
+
+        test("Simple comparison of months", async () => {
+            assertEquals(DPV({ month: 6 }).compareTo(DPV({ month: 6 })), 0);
+            assertEquals(DPV({ month: 12 }).compareTo(DPV({ month: 8 })), 1);
+            assertEquals(DPV({ month: 1 }).compareTo(DPV({ month: 2 })), -1);
+        });
+
+        test("Simple comparison of month + days", async () => {
+            assertEquals(DPV({ month: 6, day: 15 }).compareTo(DPV({ month: 6, day: 15 })), 0);
+            assertEquals(DPV({ month: 6, day: 15 }).compareTo(DPV({ month: 6, day: 14 })), 1);
+            assertEquals(DPV({ month: 6, day: 15 }).compareTo(DPV({ month: 6, day: 16 })), -1);
+            assertEquals(DPV({ month: 6, day: 15 }).compareTo(DPV({ month: 5, day: 16 })), 1);
+        });
+
+        test("comparing dates and date partial values", async () => {
+            const expectCompare = <A extends LookupValue, B extends LookupValue>(a: A, b: B, result: number) => {
+                assertEquals(a.compareTo(b), result);
+                assertEquals(b.compareTo(a), result * -1);
+            };
+            // "Jan 1, 2021" comes before "June 2021"
+            expectCompare(new DateValue(2021, 1, 1), DPV({ year: 2021, month: 6 }), -1);
+            // "May 31, 2021" comes before "June 2021"
+            expectCompare(new DateValue(2021, 5, 31), DPV({ year: 2021, month: 6 }), -1);
+            // "June 15, 2021" comes after "June 2021"
+            expectCompare(new DateValue(2021, 6, 15), DPV({ year: 2021, month: 6 }), 1);
+            // "June 1, 2021" equals "June 2021" for comparison purposes.
+            expectCompare(new DateValue(2021, 6, 1), DPV({ year: 2021, month: 6 }), 0);
+
+            // "2022" comes before "Jan 1, 2023"
+            expectCompare(DPV({ year: 2022 }), new DateValue(2023, 1, 1), -1);
+            // "2022" equals "Jan 1, 2022" for comparison purposes
+            expectCompare(DPV({ year: 2022 }), new DateValue(2022, 1, 1), 0);
+            // "2022" comes before "August 5, 2022"
+            expectCompare(DPV({ year: 2022 }), new DateValue(2022, 8, 5), -1);
+            // "2022" comes after "Dec 31, 2021"
+            expectCompare(DPV({ year: 2022 }), new DateValue(2021, 12, 31), 1);
+        });
+    });
+});

--- a/backend/neolace/core/lookup/values/DatePartialValue.ts
+++ b/backend/neolace/core/lookup/values/DatePartialValue.ts
@@ -85,13 +85,14 @@ export class DatePartialValue extends ConcreteValue {
     }
 
     protected serialize() {
-        return {
+        const v: { type: "DatePartial"; value: string; year?: number; month?: number; day?: number } = {
             type: "DatePartial" as const,
-            year: this.year,
-            month: this.month,
-            day: this.day,
             value: this.asIsoString(),
         };
+        if (this.year) v.year = this.year;
+        if (this.month) v.month = this.month;
+        if (this.day) v.day = this.day;
+        return v;
     }
 
     protected override doCastTo(_newType: ClassOf<LookupValue>, _context: LookupContext): LookupValue | undefined {
@@ -104,12 +105,12 @@ export class DatePartialValue extends ConcreteValue {
         return new DateValue(this.year ?? 9999, this.month ?? 1, this.day ?? 1);
     }
 
-    public override compareTo(otherValue: LookupValue) {
+    protected override doCompareTo(otherValue: LookupValue) {
         if (otherValue instanceof DateValue || otherValue instanceof DatePartialValue) {
             const asDate: DateValue = this.forceToDate();
             const otherDate: DateValue = otherValue instanceof DateValue ? otherValue : otherValue.forceToDate();
             return asDate.compareTo(otherDate);
         }
-        return super.compareTo(otherValue); // This will throw
+        return super.doCompareTo(otherValue); // This will throw
     }
 }

--- a/backend/neolace/core/lookup/values/DateValue.ts
+++ b/backend/neolace/core/lookup/values/DateValue.ts
@@ -64,7 +64,7 @@ export class DateValue extends ConcreteValue {
         return undefined;
     }
 
-    public override compareTo(otherValue: LookupValue) {
+    protected override doCompareTo(otherValue: LookupValue) {
         if (otherValue instanceof DateValue) {
             const yearDiff = this.year - otherValue.year;
             if (yearDiff > 0) return 1;
@@ -81,6 +81,6 @@ export class DateValue extends ConcreteValue {
                 }
             }
         }
-        return super.compareTo(otherValue); // This will throw
+        return super.doCompareTo(otherValue); // This will throw
     }
 }

--- a/backend/neolace/core/lookup/values/InlineMarkdownStringValue.ts
+++ b/backend/neolace/core/lookup/values/InlineMarkdownStringValue.ts
@@ -44,10 +44,10 @@ export class InlineMarkdownStringValue extends ConcreteValue implements IHasLite
         return undefined;
     }
 
-    public override compareTo(otherValue: LookupValue): number {
+    protected override doCompareTo(otherValue: LookupValue): number {
         if (otherValue instanceof InlineMarkdownStringValue) {
             return this.value.localeCompare(otherValue.value);
         }
-        return super.compareTo(otherValue); // This will throw
+        return super.doCompareTo(otherValue); // This will throw
     }
 }

--- a/backend/neolace/core/lookup/values/IntegerValue.ts
+++ b/backend/neolace/core/lookup/values/IntegerValue.ts
@@ -47,13 +47,13 @@ export class IntegerValue extends ConcreteValue {
         return undefined;
     }
 
-    public override compareTo(otherValue: LookupValue): number {
+    protected override doCompareTo(otherValue: LookupValue): number {
         if (otherValue instanceof IntegerValue) {
             const diff = this.value - otherValue.value;
             return diff === 0n ? 0 : diff > 0n ? 1 : -1;
         } else if (otherValue instanceof QuantityValue) {
             return new QuantityValue(Number(this.value)).compareTo(otherValue);
         }
-        return super.compareTo(otherValue); // This will throw
+        return super.doCompareTo(otherValue); // This will throw
     }
 }

--- a/backend/neolace/core/lookup/values/NullValue.ts
+++ b/backend/neolace/core/lookup/values/NullValue.ts
@@ -34,10 +34,10 @@ export class NullValue extends ConcreteValue implements IHasLiteralExpression {
         return undefined;
     }
 
-    public override compareTo(otherValue: LookupValue): number {
+    protected override doCompareTo(otherValue: LookupValue): number {
         if (otherValue instanceof NullValue) {
             return 0; // Should we make null not equal to null?
         }
-        return super.compareTo(otherValue); // This will throw
+        return super.doCompareTo(otherValue); // This will throw
     }
 }

--- a/backend/neolace/core/lookup/values/QuantityValue.ts
+++ b/backend/neolace/core/lookup/values/QuantityValue.ts
@@ -100,7 +100,7 @@ export class QuantityValue extends ConcreteValue {
         return undefined;
     }
 
-    public override compareTo(otherValue: LookupValue): number {
+    protected override doCompareTo(otherValue: LookupValue): number {
         if (otherValue instanceof QuantityValue) {
             // We always compare in terms of base units (which parsedQuantity has). This may not make sense if the
             // dimensions are different (comparing kg and m for example), but it will at least always give consistent
@@ -109,6 +109,6 @@ export class QuantityValue extends ConcreteValue {
         } else if (otherValue instanceof IntegerValue) {
             return this.parsedQuantity.magnitude - Number(otherValue.value);
         }
-        return super.compareTo(otherValue); // This will throw
+        return super.doCompareTo(otherValue); // This will throw
     }
 }

--- a/backend/neolace/core/lookup/values/StringValue.ts
+++ b/backend/neolace/core/lookup/values/StringValue.ts
@@ -58,11 +58,11 @@ export class StringValue extends ConcreteValue implements IHasLiteralExpression,
         return BigInt(this.value.length);
     }
 
-    public override compareTo(otherValue: LookupValue) {
+    protected override doCompareTo(otherValue: LookupValue) {
         if (otherValue instanceof StringValue) {
             return this.value.localeCompare(otherValue.value);
         }
-        return super.compareTo(otherValue); // This will throw
+        return super.doCompareTo(otherValue); // This will throw
     }
 
     /** Get an attribute of this value, if any, e.g. value.name or value.length */

--- a/neolace-sdk/src/content/lookup-value.ts
+++ b/neolace-sdk/src/content/lookup-value.ts
@@ -153,9 +153,9 @@ export interface DateValue extends LookupValue {
 
 export interface DatePartialValue extends LookupValue {
     type: "DatePartial";
-    year: number|undefined;
-    month: number|undefined;
-    day: number|undefined;
+    year?: number;
+    month?: number;
+    day?: number;
     /** ISO 8601 date string (YYYY, YYYY-MM, --MM, --MM-DD) */
     value: string;
 }


### PR DESCRIPTION
Fixes an error seen when sorting entries by both date and partial date values, depending on the order. The comparison was only working in one direction (e.g. comparing DatePartial to Date) but not the other (comparing Date to DatePartial).

This refactor ensures that comparisons between different value types only have to be implemented in one direction, and they'll still work in both.